### PR TITLE
test(node_lib): add large-permutation and proptest fuzz tests for rou…

### DIFF
--- a/node_lib/Cargo.toml
+++ b/node_lib/Cargo.toml
@@ -31,3 +31,4 @@ test_helpers = [ "common/test_helpers" ]
 [dev-dependencies]
 criterion = "0.5"
 common = { path = "../common/" }
+proptest = "1.0"

--- a/node_lib/src/control/mod.rs
+++ b/node_lib/src/control/mod.rs
@@ -2,4 +2,5 @@ mod client_cache;
 pub mod node;
 pub mod obu;
 mod route;
+pub mod routing_utils;
 pub mod rsu;

--- a/node_lib/src/control/routing_utils.rs
+++ b/node_lib/src/control/routing_utils.rs
@@ -1,0 +1,322 @@
+use mac_address::MacAddress;
+use std::collections::HashMap;
+
+/// Per-next-hop aggregated statistics used for scoring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NextHopStats {
+    pub min_us: u128,
+    pub sum_us: u128,
+    pub count: u32,
+}
+
+/// Given a map of next-hop -> NextHopStats, pick the best next hop by score = min + avg.
+/// Returns (MacAddress, avg_us) or None when map is empty.
+pub fn pick_best_next_hop(
+    per_next: HashMap<MacAddress, NextHopStats>,
+) -> Option<(MacAddress, u128)> {
+    let mut best: Option<(u128, MacAddress, u128)> = None; // (score, mac, avg)
+
+    for (mac, stats) in per_next.into_iter() {
+        let avg_us = if stats.count > 0 {
+            stats.sum_us / (stats.count as u128)
+        } else {
+            u128::MAX
+        };
+        let score = if stats.min_us == u128::MAX || avg_us == u128::MAX {
+            u128::MAX
+        } else {
+            stats.min_us + avg_us
+        };
+        match &mut best {
+            None => best = Some((score, mac, avg_us)),
+            Some((bscore, bmac, bavg)) => {
+                if score < *bscore || (score == *bscore && mac.bytes() < bmac.bytes()) {
+                    *bscore = score;
+                    *bmac = mac;
+                    *bavg = avg_us;
+                }
+            }
+        }
+    }
+
+    let (_score, mac, avg) = best?;
+    Some((mac, avg))
+}
+
+/// Given a latency_candidates map (mac -> (min_us, sum_us, count, hops)),
+/// compute (score=min+avg, hops, mac, avg) for each and return a sorted Vec
+/// ordered by score then hops.
+pub fn score_and_sort_latency_candidates(
+    latency_candidates: HashMap<MacAddress, (u128, u128, u32, u32)>,
+) -> Vec<(u128, u32, MacAddress, u128)> {
+    let mut scored: Vec<(u128, u32, MacAddress, u128)> = Vec::new();
+    for (mac, (min_us, sum_us, n, hops_val)) in latency_candidates.into_iter() {
+        let avg_us = if n > 0 {
+            sum_us / (n as u128)
+        } else {
+            u128::MAX
+        };
+        let score = if min_us == u128::MAX || avg_us == u128::MAX {
+            u128::MAX
+        } else {
+            min_us + avg_us
+        };
+        scored.push((score, hops_val, mac, avg_us));
+    }
+    scored.sort_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then(a.1.cmp(&b.1))
+            .then(a.2.bytes().cmp(&b.2.bytes()))
+    });
+    scored
+}
+
+/// Convenience wrapper: pick the best next hop directly from a
+/// latency_candidates map (mac -> (min_us, sum_us, count, hops)).
+/// Returns (MacAddress, avg_us) or None when empty.
+pub fn pick_best_from_latency_candidates(
+    latency_candidates: HashMap<MacAddress, (u128, u128, u32, u32)>,
+) -> Option<(MacAddress, u128)> {
+    let mut scored = score_and_sort_latency_candidates(latency_candidates);
+    if scored.is_empty() {
+        return None;
+    }
+    let (_score, _hops, mac, avg) = scored.remove(0);
+    Some((mac, avg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mac_address::MacAddress;
+
+    #[test]
+    fn pick_best_next_hop_tie_break() {
+        let a: MacAddress = [1u8, 0, 0, 0, 0, 1].into();
+        let b: MacAddress = [2u8, 0, 0, 0, 0, 2].into();
+        let mut m = HashMap::new();
+        m.insert(
+            a,
+            NextHopStats {
+                min_us: 10,
+                sum_us: 20,
+                count: 2,
+            },
+        );
+        m.insert(
+            b,
+            NextHopStats {
+                min_us: 10,
+                sum_us: 20,
+                count: 2,
+            },
+        );
+        let best = pick_best_next_hop(m).expect("some");
+        // tie-break based on bytes -> a should be chosen
+        assert_eq!(best.0.bytes(), a.bytes());
+    }
+
+    #[test]
+    fn pick_best_next_hop_none_latency_handling() {
+        let a: MacAddress = [5u8; 6].into();
+        let b: MacAddress = [6u8; 6].into();
+        let mut m = HashMap::new();
+        m.insert(
+            a,
+            NextHopStats {
+                min_us: u128::MAX,
+                sum_us: 0,
+                count: 0,
+            },
+        );
+        m.insert(
+            b,
+            NextHopStats {
+                min_us: 50,
+                sum_us: 100,
+                count: 2,
+            },
+        );
+        let best = pick_best_next_hop(m).expect("some");
+        assert_eq!(best.0, b);
+    }
+
+    #[test]
+    fn pick_best_from_latency_candidates_tie_break() {
+        let a: MacAddress = [1u8, 0, 0, 0, 0, 1].into();
+        let b: MacAddress = [2u8, 0, 0, 0, 0, 2].into();
+        let mut m = HashMap::new();
+        // Both candidates have min=10, sum=20, n=2, hops=1 -> tie on score; a should win
+        m.insert(a, (10u128, 20u128, 2u32, 1u32));
+        m.insert(b, (10u128, 20u128, 2u32, 1u32));
+        let best = super::pick_best_from_latency_candidates(m).expect("some");
+        assert_eq!(best.0.bytes(), a.bytes());
+    }
+
+    #[test]
+    fn pick_best_from_latency_candidates_none_latency_handling() {
+        let a: MacAddress = [5u8; 6].into();
+        let b: MacAddress = [6u8; 6].into();
+        let mut m = HashMap::new();
+        // a has no measurements (min=MAX, n=0), b has measurements -> b should be chosen
+        m.insert(a, (u128::MAX, 0u128, 0u32, 1u32));
+        m.insert(b, (50u128, 100u128, 2u32, 1u32));
+        let best = super::pick_best_from_latency_candidates(m).expect("some");
+        assert_eq!(best.0, b);
+    }
+
+    #[test]
+    fn pick_best_from_latency_candidates_min_finite_avg_missing() {
+        // Candidate `a` has a finite min but no avg measurements (count=0 -> avg=MAX)
+        // Candidate `b` has measured avg and should win despite a larger min value.
+        let a: MacAddress = [10u8; 6].into();
+        let b: MacAddress = [11u8; 6].into();
+        let mut m = HashMap::new();
+        // a: min=1 but n=0 -> avg=MAX -> score = MAX
+        m.insert(a, (1u128, 0u128, 0u32, 1u32));
+        // b: min=100, sum=100, n=1 -> avg=100 -> score=200
+        m.insert(b, (100u128, 100u128, 1u32, 1u32));
+        let best = super::pick_best_from_latency_candidates(m).expect("some");
+        assert_eq!(best.0, b);
+    }
+
+    #[test]
+    fn score_and_sort_latency_candidates_hops_and_mac_tie_break() {
+        // Create three candidates with equal score but different hops and MACs.
+        // Expected sort order: candidates with fewer hops come first; among equal hops, lower MAC wins.
+        let a: MacAddress = [1u8, 0, 0, 0, 0, 1].into(); // hops=2
+        let b: MacAddress = [1u8, 0, 0, 0, 0, 2].into(); // hops=1 (lower MAC than c)
+        let c: MacAddress = [1u8, 0, 0, 0, 0, 3].into(); // hops=1
+        let mut m = HashMap::new();
+        // All three will have score = 50 + 50 = 100
+        m.insert(a, (50u128, 50u128, 1u32, 2u32));
+        m.insert(b, (50u128, 50u128, 1u32, 1u32));
+        m.insert(c, (50u128, 50u128, 1u32, 1u32));
+
+        let ordered = super::score_and_sort_latency_candidates(m);
+        // Expect first == b, second == c, third == a
+        assert_eq!(ordered.len(), 3);
+        assert_eq!(ordered[0].2.bytes(), b.bytes());
+        assert_eq!(ordered[1].2.bytes(), c.bytes());
+        assert_eq!(ordered[2].2.bytes(), a.bytes());
+    }
+
+    #[test]
+    fn large_permutation_consistency() {
+        use std::collections::HashMap;
+        // Deterministic pseudo-random generator to build many candidates.
+        let mut x: u64 = 1;
+        const N: usize = 800;
+        let mut m: HashMap<MacAddress, (u128, u128, u32, u32)> = HashMap::new();
+
+        for i in 0..N {
+            // simple LCG for deterministic variability
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let min = ((x >> 5) as u128 % 400).saturating_add(1); // 1..400
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let sum = (x >> 7) as u128 % 2000; // 0..1999
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let count = (x >> 11) as u32 % 6; // 0..5 (some zero counts)
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let hops = (x >> 13) as u32 % 8; // 0..7
+
+            let ii = i as u64;
+            let bytes = [
+                (ii & 0xff) as u8,
+                ((ii >> 8) & 0xff) as u8,
+                ((ii >> 16) & 0xff) as u8,
+                ((ii >> 24) & 0xff) as u8,
+                ((ii >> 32) & 0xff) as u8,
+                ((ii >> 40) & 0xff) as u8,
+            ];
+            let mac: MacAddress = bytes.into();
+
+            m.insert(mac, (min, sum, count, hops));
+        }
+
+        // actual ordering from the helper
+        let actual = super::score_and_sort_latency_candidates(m.clone());
+
+        // build expected ordering using the same comparator logic
+        let mut expected: Vec<(u128, u32, MacAddress, u128)> = m
+            .into_iter()
+            .map(|(mac, (min_us, sum_us, n, hops))| {
+                let avg = if n > 0 {
+                    sum_us / (n as u128)
+                } else {
+                    u128::MAX
+                };
+                let score = if min_us == u128::MAX || avg == u128::MAX {
+                    u128::MAX
+                } else {
+                    min_us + avg
+                };
+                (score, hops, mac, avg)
+            })
+            .collect();
+
+        expected.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then(a.1.cmp(&b.1))
+                .then(a.2.bytes().cmp(&b.2.bytes()))
+        });
+
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert_eq!(a.0, e.0, "score mismatch");
+            assert_eq!(a.1, e.1, "hops mismatch");
+            assert_eq!(a.2.bytes(), e.2.bytes(), "mac mismatch");
+            assert_eq!(a.3, e.3, "avg mismatch");
+        }
+    }
+
+    // proptest fuzz: generate small maps and assert the helper ordering equals an explicit sort
+    #[test]
+    fn proptest_fuzz_small_maps() {
+        use proptest::prelude::*;
+
+        let strategy = prop::collection::hash_map(
+            // generate small deterministic 6-byte arrays for MAC
+            prop::array::uniform6(prop::num::u8::ANY),
+            // tuple: min, sum, count, hops
+            (0u128..1000u128, 0u128..2000u128, 0u32..5u32, 0u32..5u32),
+            1..30usize,
+        );
+
+        proptest::proptest!(|(m in strategy)| {
+            // convert keys to MacAddress
+            let mapped: std::collections::HashMap<MacAddress, (u128, u128, u32, u32)> =
+                m.into_iter().map(|(k, v)| (k.into(), v)).collect();
+
+            let actual = super::score_and_sort_latency_candidates(mapped.clone());
+
+            let mut expected: Vec<(u128, u32, MacAddress, u128)> = mapped
+                .into_iter()
+                .map(|(mac, (min_us, sum_us, n, hops))| {
+                    let avg = if n > 0 { sum_us / (n as u128) } else { u128::MAX };
+                    let score = if min_us == u128::MAX || avg == u128::MAX {
+                        u128::MAX
+                    } else {
+                        min_us + avg
+                    };
+                    (score, hops, mac, avg)
+                })
+                .collect();
+
+            expected.sort_by(|a, b| {
+                a.0
+                    .cmp(&b.0)
+                    .then(a.1.cmp(&b.1))
+                    .then(a.2.bytes().cmp(&b.2.bytes()))
+            });
+
+            prop_assert_eq!(actual.len(), expected.len());
+            for (a, e) in actual.iter().zip(expected.iter()) {
+                prop_assert_eq!(a.0, e.0);
+                prop_assert_eq!(a.1, e.1);
+                prop_assert_eq!(a.2.bytes(), e.2.bytes());
+                prop_assert_eq!(a.3, e.3);
+            }
+        });
+    }
+}

--- a/node_lib/tests/routing_integration.rs
+++ b/node_lib/tests/routing_integration.rs
@@ -1,0 +1,91 @@
+use mac_address::MacAddress;
+use node_lib::control::{obu, rsu};
+use node_lib::messages::control::heartbeat::{Heartbeat, HeartbeatReply};
+use node_lib::messages::control::Control;
+use node_lib::messages::message::Message;
+use node_lib::messages::packet_type::PacketType;
+use node_lib::Args;
+use std::time::Duration;
+use tokio::time::Instant;
+
+#[test]
+fn obu_and_rsu_choose_same_next_hop_for_same_messages() {
+    // Build Args for both
+    let args_obu = Args {
+        bind: String::default(),
+        tap_name: None,
+        ip: None,
+        mtu: 1500,
+        node_params: node_lib::args::NodeParameters {
+            node_type: node_lib::args::NodeType::Obu,
+            hello_history: 2,
+            hello_periodicity: None,
+            cached_candidates: 3,
+        },
+    };
+    let args_rsu = Args {
+        bind: String::default(),
+        tap_name: None,
+        ip: None,
+        mtu: 1500,
+        node_params: node_lib::args::NodeParameters {
+            node_type: node_lib::args::NodeType::Rsu,
+            hello_history: 2,
+            hello_periodicity: None,
+            cached_candidates: 3,
+        },
+    };
+
+    let boot = Instant::now();
+    let mut obu_routing = obu::routing::Routing::new(&args_obu, &boot).expect("obu routing");
+    let mut rsu_routing = rsu::routing::Routing::new(&args_rsu).expect("rsu routing");
+
+    // Setup a heartbeat from rsu_src observed via pkt_from. We'll then craft a reply
+    // from reply_sender forwarded by reply_from so both routings record the same info.
+    let rsu_src: MacAddress = [10u8; 6].into();
+    let pkt_from: MacAddress = [11u8; 6].into();
+    let reply_sender: MacAddress = [20u8; 6].into();
+    let reply_from: MacAddress = [21u8; 6].into();
+
+    // Create heartbeat and corresponding messages
+    let hb = Heartbeat::new(Duration::from_millis(0), 0u32, rsu_src);
+    let hb_msg = Message::new(
+        pkt_from,
+        [255u8; 6].into(),
+        PacketType::Control(Control::Heartbeat(hb.clone())),
+    );
+
+    // Feed heartbeat into obu routing (simulates observing the hello)
+    let _ = obu_routing
+        .handle_heartbeat(&hb_msg, [99u8; 6].into())
+        .expect("handled obu hb");
+
+    // For RSU routing, use send_heartbeat (creates internal sent state)
+    let _ = rsu_routing.send_heartbeat(rsu_src);
+
+    // Create a heartbeat reply where HeartbeatReply::sender() is reply_sender
+    let hbr = HeartbeatReply::from_sender(&hb, reply_sender);
+    let reply_msg = Message::new(
+        reply_from,
+        [255u8; 6].into(),
+        PacketType::Control(Control::HeartbeatReply(hbr.clone())),
+    );
+
+    // Feed reply into both routings
+    let _ = obu_routing
+        .handle_heartbeat_reply(&reply_msg, [99u8; 6].into())
+        .expect("obu handled reply");
+    let _ = rsu_routing
+        .handle_heartbeat_reply(&reply_msg, [99u8; 6].into())
+        .expect("rsu handled reply");
+
+    // Now query both for a route to reply_sender and assert next hop chosen is the same
+    let obu_route = obu_routing
+        .get_route_to(Some(reply_sender))
+        .expect("obu route");
+    let rsu_route = rsu_routing
+        .get_route_to(Some(reply_sender))
+        .expect("rsu route");
+
+    assert_eq!(obu_route.mac, rsu_route.mac);
+}


### PR DESCRIPTION
…ting utilities

- What: Add deterministic large-permutation test (N=800) and proptest-based fuzz test for .
- Why: Increase coverage and validate deterministic tie-break behavior across larger candidate sets and randomized small maps.
- How: Updated tests and added as fuzzing a dev-dependency .
- Testing: Ran running 67 tests
test control::node::tests::get_msgs_ok_none ... ok test control::node::tests::get_msgs_ok_some_with_unparsable_wire ... ok test control::client_cache::tests::storing_same_mapping_is_noop ... ok test control::obu::obu_tests::downstream_to_self_returns_tap ... ok test control::obu::obu_tests::upstream_with_no_cached_upstream_returns_none ... ok test control::client_cache::tests::store_and_get_mac ... ok test control::obu::obu_tests::downstream_to_other_returns_none_when_no_route ... ok test control::obu::obu_tests::heartbeat_generates_forward_and_reply ... ok test control::node::tests::get_msgs_ok_some_with_parsable_wire ... ok test control::obu::obu_tests::downstream_to_other_forwards_wire_when_route_exists ... ok test control::obu::routing::cache_tests::select_and_cache_upstream_sets_cache ... ok test control::obu::routing::more_tests::get_route_to_none_when_empty ... ok test control::obu::obu_tests::upstream_with_cached_upstream_returns_wire ... ok test control::obu::routing::cache_tests::failover_promotes_next_candidate ... ok test control::obu::routing::more_tests::clear_cached_upstream_removes_cache ... ok test control::obu::routing::more_tests::duplicate_heartbeat_returns_none ... ok test control::obu::obu_tests::heartbeat_reply_updates_routing_and_replies ... ok test control::obu::routing::more_tests::hysteresis_keeps_cached_when_hops_equal ... ok test control::obu::routing::more_tests::hello_history_eviction_keeps_latest ... ok test control::obu::routing::more_tests::hysteresis_switches_when_one_fewer_hop ... ok test control::obu::routing::more_tests::tie_break_prefers_lower_mac_when_scores_equal ... ok test control::route::tests::route_display_with_latency_some ... ok test control::obu::routing::more_tests::none_latency_handling_prefers_min_and_none_ignored_in_avg ... ok test control::obu::routing::regression_tests::heartbeat_reply_from_sender_triggers_bail ... ok test control::route::tests::route_display_contains_fields ... ok test control::routing_utils::tests::pick_best_next_hop_tie_break ... ok test control::routing_utils::tests::score_and_sort_latency_candidates_hops_and_mac_tie_break ... ok test control::obu::routing::tests::handle_heartbeat_reply_updates_downstream_and_replies ... ok test control::obu::routing::more_tests::out_of_order_id_clears_prior_entries ... ok test control::obu::routing::more_tests::select_and_cache_upstream_none_when_no_routes ... ok test control::rsu::routing::more_tests::iter_next_hops_empty_and_get_route_none_when_empty ... ok test control::rsu::routing::tests::can_generate_heartbeat ... ok test control::rsu::routing::tests::rsu_handle_heartbeat_reply_inserts_route ... ok test control::obu::routing::more_tests::hysteresis_prefers_measured_when_cached_unmeasured ... ok test control::rsu::rsu_tests::heartbeat_reply_for_other_source_returns_none ... ok test control::obu::routing::regression_tests::heartbeat_reply_from_next_hop_does_not_bail ... ok test control::rsu::rsu_tests::upstream_broadcast_generates_tap ... ok test messages::control::heartbeat::tests::create_hearbeat ... ok test control::obu::routing::more_tests::hysteresis_latency_improvement_above_10_percent_switches ... ok test control::rsu::rsu_tests::upstream_unicast_to_self_yields_tap_only ... ok test messages::control::heartbeat::tests::heartbeat_can_be_parsed_and_has_correct_members ... ok test control::obu::routing::more_tests::hysteresis_latency_improvement_below_10_percent_keeps_cached ... ok test control::rsu::rsu_tests::upstream_unicast_forwards_via_route ... ok test messages::control::heartbeat::tests::heartbeat_reply_can_be_parsed_and_has_correct_members ... ok test control::obu::routing::tests::handle_heartbeat_creates_route_and_returns_replies ... ok test messages::control::heartbeat::tests::heartbeat_try_from_too_short_fails ... ok test control::routing_utils::tests::pick_best_from_latency_candidates_min_finite_avg_missing ... ok test control::routing_utils::tests::pick_best_from_latency_candidates_none_latency_handling ... ok test messages::data::tests::data_invalid_first_byte_is_error ... ok test control::routing_utils::tests::pick_best_next_hop_none_latency_handling ... ok test messages::message::tests::message_not_from_this_protocol_cannot_be_built ... ok test messages::data::tests::to_upstream_parse_and_roundtrip ... ok test messages::control::heartbeat::tests::heartbeat_reply_try_from_too_short_fails ... ok test messages::message::tests::message_too_short_is_error ... ok test messages::message::tests::message_with_no_packet_type_is_error ... ok test control::obu::routing::more_tests::test_latency_measurement_with_mocked_time ... ok test control::routing_utils::tests::pick_best_from_latency_candidates_tie_break ... ok test messages::packet_type::tests::packet_type_invalid_first_byte_is_error ... ok test messages::packet_type::tests::packet_type_roundtrip_control ... ok test messages::data::tests::to_downstream_parse_and_roundtrip ... ok test messages::packet_type::tests::packet_type_roundtrip_data ... ok test messages::packet_type::tests::packet_type_too_short_is_error ... ok test tests::create_in_test_build_bails ... ok
test tests::init_test_tracing_is_idempotent ... ok test tests::create_with_vdev_obu_and_rsu ... ok
test control::routing_utils::tests::large_permutation_consistency ... ok test control::routing_utils::tests::proptest_fuzz_small_maps ... ok

test result: ok. 67 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 1 test
[2m2025-09-05T10:28:22.232726Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.240527Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.240581Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.254052Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.275645Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.290388Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.290440Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.297592Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.319164Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.340408Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.340633Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } [2m2025-09-05T10:28:22.340645Z[0m [31mERROR[0m [2mnode_lib::control::node[0m[2m:[0m error sending to dev [3me[0m[2m=[0mOs { code: 32, kind: BrokenPipe, message: "Broken pipe" } test obu_promotes_on_primary_send_failure_via_hub_closure ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s

running 1 test
test handle_messages_sends_to_tun_and_device ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 1 test
test test_latency_measurement_with_mocked_time ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 1 test
test rsu_and_obu_topology_discovery ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 2 tests
test rsu_and_two_obus_choose_two_hop_when_direct_has_higher_latency ... ok test two_hop_ping_roundtrip_obu2_to_rsu ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 1 test
test obu_and_rsu_choose_same_next_hop_for_same_messages ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s locally; all tests passed.