### PR TITLE
refactor(messages): split Auth messages out of Control enum

### DIFF
--- a/node_lib/src/crypto.rs
+++ b/node_lib/src/crypto.rs
@@ -113,6 +113,27 @@ pub enum DhGroup {
     MlKem768,
 }
 
+impl DhGroup {
+    /// Returns the wire-format byte identifier for this DH group.
+    pub fn wire_id(self) -> u8 {
+        match self {
+            Self::X25519 => 0x01,
+            Self::MlKem768 => 0x02,
+        }
+    }
+
+    /// Maps a wire-format byte back to a [`DhGroup`].
+    ///
+    /// Returns `None` for unrecognised IDs.
+    pub fn from_wire_id(id: u8) -> Option<Self> {
+        match id {
+            0x01 => Some(Self::X25519),
+            0x02 => Some(Self::MlKem768),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Display for DhGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -145,6 +166,27 @@ pub enum SigningAlgorithm {
     /// ML-DSA-65 (NIST FIPS 204) — quantum-resistant digital signature.
     /// Verifying key: 1952 bytes; signature: 3309 bytes.
     MlDsa65,
+}
+
+impl SigningAlgorithm {
+    /// Returns the wire-format byte identifier for this signing algorithm.
+    pub fn wire_id(self) -> u8 {
+        match self {
+            Self::Ed25519 => 0x01,
+            Self::MlDsa65 => 0x02,
+        }
+    }
+
+    /// Maps a wire-format byte back to a [`SigningAlgorithm`].
+    ///
+    /// Returns `None` for unrecognised IDs — callers should drop the message.
+    pub fn from_wire_id(id: u8) -> Option<Self> {
+        match id {
+            0x01 => Some(Self::Ed25519),
+            0x02 => Some(Self::MlDsa65),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for SigningAlgorithm {
@@ -379,18 +421,6 @@ pub fn decode_hex_32(s: &str) -> Option<[u8; 32]> {
         .map(|i| u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok())
         .collect();
     bytes.and_then(|b| b.try_into().ok())
-}
-
-/// Map a wire-format signature algorithm ID to a [`SigningAlgorithm`].
-///
-/// Returns `None` for unrecognised IDs — callers should drop the message.
-pub fn sig_algo_from_id(id: u8) -> Option<SigningAlgorithm> {
-    use crate::messages::control::key_exchange::{SIG_ALGO_ED25519, SIG_ALGO_ML_DSA_65};
-    match id {
-        SIG_ALGO_ED25519 => Some(SigningAlgorithm::Ed25519),
-        SIG_ALGO_ML_DSA_65 => Some(SigningAlgorithm::MlDsa65),
-        _ => None,
-    }
 }
 
 /// Verify a DH key exchange signature.

--- a/node_lib/src/messages/auth/key_exchange.rs
+++ b/node_lib/src/messages/auth/key_exchange.rs
@@ -2,17 +2,7 @@ use std::borrow::Cow;
 
 use mac_address::MacAddress;
 
-// ── Algorithm identifiers ─────────────────────────────────────────────
-
-/// Key-exchange algorithm: X25519 ECDH.
-pub const KE_ALGO_X25519: u8 = 0x01;
-/// Key-exchange algorithm: ML-KEM-768 (NIST FIPS 203).
-pub const KE_ALGO_ML_KEM_768: u8 = 0x02;
-
-/// Signing algorithm: Ed25519.
-pub const SIG_ALGO_ED25519: u8 = 0x01;
-/// Signing algorithm: ML-DSA-65 (NIST FIPS 204).
-pub const SIG_ALGO_ML_DSA_65: u8 = 0x02;
+use crate::crypto::{DhGroup, SigningAlgorithm};
 
 // ── Wire format sizes ─────────────────────────────────────────────────
 //
@@ -22,12 +12,6 @@ pub const SIG_ALGO_ML_DSA_65: u8 = 0x02;
 // Signed extension (appended after base):
 //   sig_algo_id (1) | signing_pubkey_len (2 BE) | signing_pubkey (var)
 //   | signature_len (2 BE) | signature (var)
-//
-// X25519 key_material = 32 bytes DH public key
-// ML-KEM-768 Init key_material = 1184 bytes encapsulation key
-// ML-KEM-768 Reply key_material = 1088 bytes ciphertext
-// Ed25519 signing_pubkey = 32 bytes, signature = 64 bytes
-// ML-DSA-65 signing_pubkey = 1952 bytes, signature = 3309 bytes
 
 /// Minimum bytes needed to read the base header before key_material.
 /// algo_id(1) + key_id(4) + key_material_len(2) = 7 bytes.
@@ -61,22 +45,29 @@ pub const ED25519_SIG_LEN: usize = 64;
 /// For ML-KEM-768: `key_material` = 1184-byte encapsulation key.
 #[derive(Debug, Clone)]
 pub struct KeyExchangeInit<'a> {
+    /// Wire-format algorithm byte (derived from DhGroup).
     algo_id: u8,
     key_id: Cow<'a, [u8]>,
     key_material: Cow<'a, [u8]>,
     sender: Cow<'a, [u8]>,
+    /// Wire-format sig algorithm byte (derived from SigningAlgorithm), if signed.
     sig_algo_id: Option<u8>,
     signing_pubkey: Option<Cow<'a, [u8]>>,
     signature: Option<Cow<'a, [u8]>>,
 }
 
 impl<'a> KeyExchangeInit<'a> {
-    /// Create an unsigned X25519 message.
-    pub fn new(key_id: u32, public_key: [u8; 32], sender: MacAddress) -> Self {
+    /// Create an unsigned key exchange initiation.
+    pub fn new_unsigned(
+        dh_group: DhGroup,
+        key_id: u32,
+        key_material: Vec<u8>,
+        sender: MacAddress,
+    ) -> Self {
         Self {
-            algo_id: KE_ALGO_X25519,
+            algo_id: dh_group.wire_id(),
             key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(public_key.to_vec()),
+            key_material: Cow::Owned(key_material),
             sender: Cow::Owned(sender.bytes().to_vec()),
             sig_algo_id: None,
             signing_pubkey: None,
@@ -84,86 +75,27 @@ impl<'a> KeyExchangeInit<'a> {
         }
     }
 
-    /// Create a signed X25519 message (Ed25519 signature).
+    /// Create a signed key exchange initiation.
     pub fn new_signed(
+        dh_group: DhGroup,
         key_id: u32,
-        public_key: [u8; 32],
+        key_material: Vec<u8>,
         sender: MacAddress,
-        signing_pubkey: [u8; 32],
-        signature: [u8; 64],
-    ) -> Self {
-        Self {
-            algo_id: KE_ALGO_X25519,
-            key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(public_key.to_vec()),
-            sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id: Some(SIG_ALGO_ED25519),
-            signing_pubkey: Some(Cow::Owned(signing_pubkey.to_vec())),
-            signature: Some(Cow::Owned(signature.to_vec())),
-        }
-    }
-
-    /// Create an unsigned ML-KEM-768 message.
-    /// `encap_key` is the 1184-byte encapsulation (public) key.
-    pub fn new_ml_kem_768(
-        key_id: u32,
-        encap_key: &[u8; crate::crypto::ML_KEM_768_EK_LEN],
-        sender: MacAddress,
-    ) -> Self {
-        Self {
-            algo_id: KE_ALGO_ML_KEM_768,
-            key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(encap_key.to_vec()),
-            sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id: None,
-            signing_pubkey: None,
-            signature: None,
-        }
-    }
-
-    /// Create a signed ML-KEM-768 message with variable-length signing data.
-    /// `sig_algo_id` should be `SIG_ALGO_ED25519` or `SIG_ALGO_ML_DSA_65`.
-    pub fn new_ml_kem_768_signed(
-        key_id: u32,
-        encap_key: &[u8; crate::crypto::ML_KEM_768_EK_LEN],
-        sender: MacAddress,
-        sig_algo: u8,
+        sig_algo: SigningAlgorithm,
         signing_pubkey: Vec<u8>,
         signature: Vec<u8>,
     ) -> Self {
         Self {
-            algo_id: KE_ALGO_ML_KEM_768,
+            algo_id: dh_group.wire_id(),
             key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(encap_key.to_vec()),
+            key_material: Cow::Owned(key_material),
             sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id: Some(sig_algo),
+            sig_algo_id: Some(sig_algo.wire_id()),
             signing_pubkey: Some(Cow::Owned(signing_pubkey)),
             signature: Some(Cow::Owned(signature)),
         }
     }
 
-    /// Create a message from raw parts (for forwarding without reconstructing).
-    pub fn new_raw(
-        algo_id: u8,
-        key_id: u32,
-        key_material: Vec<u8>,
-        sender: MacAddress,
-        sig_algo_id: Option<u8>,
-        signing_pubkey: Option<Vec<u8>>,
-        signature: Option<Vec<u8>>,
-    ) -> Self {
-        Self {
-            algo_id,
-            key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(key_material),
-            sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id,
-            signing_pubkey: signing_pubkey.map(Cow::Owned),
-            signature: signature.map(Cow::Owned),
-        }
-    }
-
-    /// Clone into an owned (static lifetime) message for forwarding.
     pub fn clone_into_owned(&self) -> KeyExchangeInit<'static> {
         KeyExchangeInit {
             algo_id: self.algo_id,
@@ -176,8 +108,9 @@ impl<'a> KeyExchangeInit<'a> {
         }
     }
 
-    pub fn algo_id(&self) -> u8 {
-        self.algo_id
+    /// Returns the DH group for this message, or `None` for unrecognised wire IDs.
+    pub fn dh_group(&self) -> Option<DhGroup> {
+        DhGroup::from_wire_id(self.algo_id)
     }
 
     pub fn key_id(&self) -> u32 {
@@ -190,12 +123,11 @@ impl<'a> KeyExchangeInit<'a> {
         )
     }
 
-    /// Return the key material bytes (DH public key for X25519, encap key for ML-KEM-768).
     pub fn key_material(&self) -> &[u8] {
         &self.key_material
     }
 
-    /// Convenience: return the 32-byte X25519 public key. Panics if not X25519.
+    /// Convenience: return the 32-byte X25519 public key. Panics if not X25519 / wrong size.
     pub fn public_key(&self) -> [u8; 32] {
         self.key_material
             .get(0..32)
@@ -214,16 +146,15 @@ impl<'a> KeyExchangeInit<'a> {
         )
     }
 
-    pub fn sig_algo_id(&self) -> Option<u8> {
-        self.sig_algo_id
+    /// Returns the signing algorithm, or `None` if unsigned or unrecognised wire ID.
+    pub fn signing_algorithm(&self) -> Option<SigningAlgorithm> {
+        self.sig_algo_id.and_then(SigningAlgorithm::from_wire_id)
     }
 
-    /// Return the signing public key bytes, if present.
     pub fn signing_pubkey(&self) -> Option<&[u8]> {
         self.signing_pubkey.as_deref()
     }
 
-    /// Return the signature bytes, if present.
     pub fn signature(&self) -> Option<&[u8]> {
         self.signature.as_deref()
     }
@@ -232,7 +163,8 @@ impl<'a> KeyExchangeInit<'a> {
         self.sig_algo_id.is_some() && self.signing_pubkey.is_some() && self.signature.is_some()
     }
 
-    /// Return the base payload bytes that were (or should be) signed.
+    /// Return the base payload bytes to be signed (or verified against).
+    ///
     /// Covers: algo_id | key_id | key_material_len | key_material | sender.
     pub fn base_payload(&self) -> Vec<u8> {
         let km_len = self.key_material.len() as u16;
@@ -243,6 +175,19 @@ impl<'a> KeyExchangeInit<'a> {
         buf.extend_from_slice(&self.key_material);
         buf.extend_from_slice(&self.sender);
         buf
+    }
+
+    /// Wire size in bytes without allocating.
+    pub fn wire_size(&self) -> usize {
+        // algo_id(1) + key_id(4) + km_len(2) + key_material + sender(6)
+        let base = 1 + self.key_id.len() + 2 + self.key_material.len() + self.sender.len();
+        match (&self.sig_algo_id, &self.signing_pubkey, &self.signature) {
+            (Some(_), Some(spk), Some(sig)) => {
+                // sig_algo_id(1) + spk_len(2) + spk + sig_len(2) + sig
+                base + 1 + 2 + spk.len() + 2 + sig.len()
+            }
+            _ => base,
+        }
     }
 }
 
@@ -282,22 +227,21 @@ impl<'a> TryFrom<&'a [u8]> for KeyExchangeInit<'a> {
                 ));
             }
             let sig_algo = ext[0];
+            let signing_algo = SigningAlgorithm::from_wire_id(sig_algo).ok_or_else(|| {
+                crate::error::NodeError::InvalidMessage(format!(
+                    "KeyExchangeInit unknown sig_algo_id {sig_algo}"
+                ))
+            })?;
             let spk_len = u16::from_be_bytes([ext[1], ext[2]]) as usize;
-            // Reject key/sig sizes that don't match the declared algorithm.
-            let (expected_spk_len, expected_sig_len) = match sig_algo {
-                SIG_ALGO_ED25519 => (
+            let (expected_spk_len, expected_sig_len) = match signing_algo {
+                SigningAlgorithm::Ed25519 => (
                     crate::crypto::ED25519_VK_LEN,
                     crate::crypto::ED25519_SIG_LEN,
                 ),
-                SIG_ALGO_ML_DSA_65 => (
+                SigningAlgorithm::MlDsa65 => (
                     crate::crypto::ML_DSA_65_VK_LEN,
                     crate::crypto::ML_DSA_65_SIG_LEN,
                 ),
-                _ => {
-                    return Err(crate::error::NodeError::InvalidMessage(format!(
-                        "KeyExchangeInit unknown sig_algo_id {sig_algo}"
-                    )));
-                }
             };
             if spk_len != expected_spk_len {
                 return Err(crate::error::NodeError::InvalidMessage(format!(
@@ -351,21 +295,6 @@ impl<'a> TryFrom<&'a [u8]> for KeyExchangeInit<'a> {
     }
 }
 
-impl<'a> KeyExchangeInit<'a> {
-    /// Wire size in bytes without allocating.
-    pub fn wire_size(&self) -> usize {
-        // algo_id(1) + key_id(4) + km_len(2) + key_material + sender(6)
-        let base = 1 + self.key_id.len() + 2 + self.key_material.len() + self.sender.len();
-        match (&self.sig_algo_id, &self.signing_pubkey, &self.signature) {
-            (Some(_), Some(spk), Some(sig)) => {
-                // sig_algo_id(1) + spk_len(2) + spk + sig_len(2) + sig
-                base + 1 + 2 + spk.len() + 2 + sig.len()
-            }
-            _ => base,
-        }
-    }
-}
-
 impl<'a> From<&KeyExchangeInit<'a>> for Vec<u8> {
     fn from(value: &KeyExchangeInit<'a>) -> Self {
         let km_len = value.key_material.len() as u16;
@@ -410,12 +339,17 @@ pub struct KeyExchangeReply<'a> {
 }
 
 impl<'a> KeyExchangeReply<'a> {
-    /// Create an unsigned X25519 reply.
-    pub fn new(key_id: u32, public_key: [u8; 32], sender: MacAddress) -> Self {
+    /// Create an unsigned key exchange reply.
+    pub fn new_unsigned(
+        dh_group: DhGroup,
+        key_id: u32,
+        key_material: Vec<u8>,
+        sender: MacAddress,
+    ) -> Self {
         Self {
-            algo_id: KE_ALGO_X25519,
+            algo_id: dh_group.wire_id(),
             key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(public_key.to_vec()),
+            key_material: Cow::Owned(key_material),
             sender: Cow::Owned(sender.bytes().to_vec()),
             sig_algo_id: None,
             signing_pubkey: None,
@@ -423,85 +357,27 @@ impl<'a> KeyExchangeReply<'a> {
         }
     }
 
-    /// Create a signed X25519 reply (Ed25519 signature).
+    /// Create a signed key exchange reply.
     pub fn new_signed(
+        dh_group: DhGroup,
         key_id: u32,
-        public_key: [u8; 32],
+        key_material: Vec<u8>,
         sender: MacAddress,
-        signing_pubkey: [u8; 32],
-        signature: [u8; 64],
-    ) -> Self {
-        Self {
-            algo_id: KE_ALGO_X25519,
-            key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(public_key.to_vec()),
-            sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id: Some(SIG_ALGO_ED25519),
-            signing_pubkey: Some(Cow::Owned(signing_pubkey.to_vec())),
-            signature: Some(Cow::Owned(signature.to_vec())),
-        }
-    }
-
-    /// Create an unsigned ML-KEM-768 reply.
-    /// `ciphertext` is the 1088-byte KEM ciphertext.
-    pub fn new_ml_kem_768(
-        key_id: u32,
-        ciphertext: &[u8; crate::crypto::ML_KEM_768_CT_LEN],
-        sender: MacAddress,
-    ) -> Self {
-        Self {
-            algo_id: KE_ALGO_ML_KEM_768,
-            key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(ciphertext.to_vec()),
-            sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id: None,
-            signing_pubkey: None,
-            signature: None,
-        }
-    }
-
-    /// Create a signed ML-KEM-768 reply with variable-length signing data.
-    pub fn new_ml_kem_768_signed(
-        key_id: u32,
-        ciphertext: &[u8; crate::crypto::ML_KEM_768_CT_LEN],
-        sender: MacAddress,
-        sig_algo: u8,
+        sig_algo: SigningAlgorithm,
         signing_pubkey: Vec<u8>,
         signature: Vec<u8>,
     ) -> Self {
         Self {
-            algo_id: KE_ALGO_ML_KEM_768,
+            algo_id: dh_group.wire_id(),
             key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(ciphertext.to_vec()),
+            key_material: Cow::Owned(key_material),
             sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id: Some(sig_algo),
+            sig_algo_id: Some(sig_algo.wire_id()),
             signing_pubkey: Some(Cow::Owned(signing_pubkey)),
             signature: Some(Cow::Owned(signature)),
         }
     }
 
-    /// Create a reply from raw parts (for forwarding without reconstructing).
-    pub fn new_raw(
-        algo_id: u8,
-        key_id: u32,
-        key_material: Vec<u8>,
-        sender: MacAddress,
-        sig_algo_id: Option<u8>,
-        signing_pubkey: Option<Vec<u8>>,
-        signature: Option<Vec<u8>>,
-    ) -> Self {
-        Self {
-            algo_id,
-            key_id: Cow::Owned(key_id.to_be_bytes().to_vec()),
-            key_material: Cow::Owned(key_material),
-            sender: Cow::Owned(sender.bytes().to_vec()),
-            sig_algo_id,
-            signing_pubkey: signing_pubkey.map(Cow::Owned),
-            signature: signature.map(Cow::Owned),
-        }
-    }
-
-    /// Clone into an owned (static lifetime) message for forwarding.
     pub fn clone_into_owned(&self) -> KeyExchangeReply<'static> {
         KeyExchangeReply {
             algo_id: self.algo_id,
@@ -514,8 +390,9 @@ impl<'a> KeyExchangeReply<'a> {
         }
     }
 
-    pub fn algo_id(&self) -> u8 {
-        self.algo_id
+    /// Returns the DH group for this message, or `None` for unrecognised wire IDs.
+    pub fn dh_group(&self) -> Option<DhGroup> {
+        DhGroup::from_wire_id(self.algo_id)
     }
 
     pub fn key_id(&self) -> u32 {
@@ -528,12 +405,11 @@ impl<'a> KeyExchangeReply<'a> {
         )
     }
 
-    /// Return the key material bytes (DH public key for X25519, ciphertext for ML-KEM-768).
     pub fn key_material(&self) -> &[u8] {
         &self.key_material
     }
 
-    /// Convenience: return the 32-byte X25519 public key. Panics if not X25519.
+    /// Convenience: return the 32-byte X25519 public key. Panics if not X25519 / wrong size.
     pub fn public_key(&self) -> [u8; 32] {
         self.key_material
             .get(0..32)
@@ -552,8 +428,9 @@ impl<'a> KeyExchangeReply<'a> {
         )
     }
 
-    pub fn sig_algo_id(&self) -> Option<u8> {
-        self.sig_algo_id
+    /// Returns the signing algorithm, or `None` if unsigned or unrecognised wire ID.
+    pub fn signing_algorithm(&self) -> Option<SigningAlgorithm> {
+        self.sig_algo_id.and_then(SigningAlgorithm::from_wire_id)
     }
 
     pub fn signing_pubkey(&self) -> Option<&[u8]> {
@@ -568,7 +445,7 @@ impl<'a> KeyExchangeReply<'a> {
         self.sig_algo_id.is_some() && self.signing_pubkey.is_some() && self.signature.is_some()
     }
 
-    /// Return the base payload bytes that were (or should be) signed.
+    /// Return the base payload bytes to be signed (or verified against).
     pub fn base_payload(&self) -> Vec<u8> {
         let km_len = self.key_material.len() as u16;
         let mut buf = Vec::with_capacity(KE_HEADER_LEN + self.key_material.len() + KE_SENDER_LEN);
@@ -578,6 +455,15 @@ impl<'a> KeyExchangeReply<'a> {
         buf.extend_from_slice(&self.key_material);
         buf.extend_from_slice(&self.sender);
         buf
+    }
+
+    /// Wire size in bytes without allocating.
+    pub fn wire_size(&self) -> usize {
+        let base = 1 + self.key_id.len() + 2 + self.key_material.len() + self.sender.len();
+        match (&self.sig_algo_id, &self.signing_pubkey, &self.signature) {
+            (Some(_), Some(spk), Some(sig)) => base + 1 + 2 + spk.len() + 2 + sig.len(),
+            _ => base,
+        }
     }
 }
 
@@ -616,21 +502,21 @@ impl<'a> TryFrom<&'a [u8]> for KeyExchangeReply<'a> {
                 ));
             }
             let sig_algo = ext[0];
+            let signing_algo = SigningAlgorithm::from_wire_id(sig_algo).ok_or_else(|| {
+                crate::error::NodeError::InvalidMessage(format!(
+                    "KeyExchangeReply unknown sig_algo_id {sig_algo}"
+                ))
+            })?;
             let spk_len = u16::from_be_bytes([ext[1], ext[2]]) as usize;
-            let (expected_spk_len, expected_sig_len) = match sig_algo {
-                SIG_ALGO_ED25519 => (
+            let (expected_spk_len, expected_sig_len) = match signing_algo {
+                SigningAlgorithm::Ed25519 => (
                     crate::crypto::ED25519_VK_LEN,
                     crate::crypto::ED25519_SIG_LEN,
                 ),
-                SIG_ALGO_ML_DSA_65 => (
+                SigningAlgorithm::MlDsa65 => (
                     crate::crypto::ML_DSA_65_VK_LEN,
                     crate::crypto::ML_DSA_65_SIG_LEN,
                 ),
-                _ => {
-                    return Err(crate::error::NodeError::InvalidMessage(format!(
-                        "KeyExchangeReply unknown sig_algo_id {sig_algo}"
-                    )));
-                }
             };
             if spk_len != expected_spk_len {
                 return Err(crate::error::NodeError::InvalidMessage(format!(
@@ -684,21 +570,6 @@ impl<'a> TryFrom<&'a [u8]> for KeyExchangeReply<'a> {
     }
 }
 
-impl<'a> KeyExchangeReply<'a> {
-    /// Wire size in bytes without allocating.
-    pub fn wire_size(&self) -> usize {
-        // algo_id(1) + key_id(4) + km_len(2) + key_material + sender(6)
-        let base = 1 + self.key_id.len() + 2 + self.key_material.len() + self.sender.len();
-        match (&self.sig_algo_id, &self.signing_pubkey, &self.signature) {
-            (Some(_), Some(spk), Some(sig)) => {
-                // sig_algo_id(1) + spk_len(2) + spk + sig_len(2) + sig
-                base + 1 + 2 + spk.len() + 2 + sig.len()
-            }
-            _ => base,
-        }
-    }
-}
-
 impl<'a> From<&KeyExchangeReply<'a>> for Vec<u8> {
     fn from(value: &KeyExchangeReply<'a>) -> Self {
         let km_len = value.key_material.len() as u16;
@@ -743,12 +614,13 @@ mod tests {
         let public_key = [7u8; 32];
         let sender: MacAddress = [1, 2, 3, 4, 5, 6].into();
 
-        let init = KeyExchangeInit::new(key_id, public_key, sender);
+        let init =
+            KeyExchangeInit::new_unsigned(DhGroup::X25519, key_id, public_key.to_vec(), sender);
         assert_eq!(init.key_id(), key_id);
         assert_eq!(init.public_key(), public_key);
         assert_eq!(init.sender(), sender);
         assert!(!init.is_signed());
-        assert_eq!(init.algo_id(), KE_ALGO_X25519);
+        assert_eq!(init.dh_group(), Some(DhGroup::X25519));
 
         let bytes: Vec<u8> = (&init).into();
         assert_eq!(bytes.len(), x25519_unsigned_len());
@@ -766,7 +638,8 @@ mod tests {
         let public_key = [0xAB; 32];
         let sender: MacAddress = [10, 20, 30, 40, 50, 60].into();
 
-        let reply = KeyExchangeReply::new(key_id, public_key, sender);
+        let reply =
+            KeyExchangeReply::new_unsigned(DhGroup::X25519, key_id, public_key.to_vec(), sender);
         assert_eq!(reply.key_id(), key_id);
         assert_eq!(reply.public_key(), public_key);
         assert_eq!(reply.sender(), sender);
@@ -802,12 +675,19 @@ mod tests {
         let signing_pubkey = [0x22u8; 32];
         let signature = [0x33u8; 64];
 
-        let init =
-            KeyExchangeInit::new_signed(key_id, public_key, sender, signing_pubkey, signature);
+        let init = KeyExchangeInit::new_signed(
+            DhGroup::X25519,
+            key_id,
+            public_key.to_vec(),
+            sender,
+            SigningAlgorithm::Ed25519,
+            signing_pubkey.to_vec(),
+            signature.to_vec(),
+        );
         assert!(init.is_signed());
         assert_eq!(init.signing_pubkey(), Some(signing_pubkey.as_ref()));
         assert_eq!(init.signature(), Some(signature.as_ref()));
-        assert_eq!(init.sig_algo_id(), Some(SIG_ALGO_ED25519));
+        assert_eq!(init.signing_algorithm(), Some(SigningAlgorithm::Ed25519));
 
         let bytes: Vec<u8> = (&init).into();
         assert_eq!(bytes.len(), x25519_signed_len());
@@ -829,8 +709,15 @@ mod tests {
         let signing_pubkey = [0x66u8; 32];
         let signature = [0x77u8; 64];
 
-        let reply =
-            KeyExchangeReply::new_signed(key_id, public_key, sender, signing_pubkey, signature);
+        let reply = KeyExchangeReply::new_signed(
+            DhGroup::X25519,
+            key_id,
+            public_key.to_vec(),
+            sender,
+            SigningAlgorithm::Ed25519,
+            signing_pubkey.to_vec(),
+            signature.to_vec(),
+        );
         assert!(reply.is_signed());
 
         let bytes: Vec<u8> = (&reply).into();
@@ -850,11 +737,12 @@ mod tests {
         let key_id = 1u32;
         let public_key = [0xAAu8; 32];
         let sender: MacAddress = [1, 2, 3, 4, 5, 6].into();
-        let init = KeyExchangeInit::new(key_id, public_key, sender);
+        let init =
+            KeyExchangeInit::new_unsigned(DhGroup::X25519, key_id, public_key.to_vec(), sender);
         let base = init.base_payload();
         // algo_id(1) + key_id(4) + km_len(2) + key(32) + sender(6)
         assert_eq!(base.len(), 1 + 4 + 2 + 32 + 6);
-        assert_eq!(base[0], KE_ALGO_X25519);
+        assert_eq!(base[0], DhGroup::X25519.wire_id());
         assert_eq!(&base[1..5], &1u32.to_be_bytes());
         assert_eq!(&base[7..39], &[0xAAu8; 32]);
         assert_eq!(&base[39..45], &[1, 2, 3, 4, 5, 6]);
@@ -866,8 +754,9 @@ mod tests {
         let encap_key = [0xBBu8; crate::crypto::ML_KEM_768_EK_LEN];
         let sender: MacAddress = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66].into();
 
-        let init = KeyExchangeInit::new_ml_kem_768(key_id, &encap_key, sender);
-        assert_eq!(init.algo_id(), KE_ALGO_ML_KEM_768);
+        let init =
+            KeyExchangeInit::new_unsigned(DhGroup::MlKem768, key_id, encap_key.to_vec(), sender);
+        assert_eq!(init.dh_group(), Some(DhGroup::MlKem768));
         assert_eq!(init.key_id(), key_id);
         assert_eq!(init.key_material(), encap_key.as_ref());
         assert!(!init.is_signed());
@@ -877,7 +766,7 @@ mod tests {
         assert_eq!(bytes.len(), 1 + 4 + 2 + 1184 + 6);
 
         let parsed = KeyExchangeInit::try_from(&bytes[..]).expect("parse ml-kem init");
-        assert_eq!(parsed.algo_id(), KE_ALGO_ML_KEM_768);
+        assert_eq!(parsed.dh_group(), Some(DhGroup::MlKem768));
         assert_eq!(parsed.key_id(), key_id);
         assert_eq!(parsed.key_material(), encap_key.as_ref());
         assert_eq!(parsed.sender(), sender);
@@ -889,8 +778,9 @@ mod tests {
         let ciphertext = [0xCCu8; crate::crypto::ML_KEM_768_CT_LEN];
         let sender: MacAddress = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF].into();
 
-        let reply = KeyExchangeReply::new_ml_kem_768(key_id, &ciphertext, sender);
-        assert_eq!(reply.algo_id(), KE_ALGO_ML_KEM_768);
+        let reply =
+            KeyExchangeReply::new_unsigned(DhGroup::MlKem768, key_id, ciphertext.to_vec(), sender);
+        assert_eq!(reply.dh_group(), Some(DhGroup::MlKem768));
         assert_eq!(reply.key_material(), ciphertext.as_ref());
 
         let bytes: Vec<u8> = (&reply).into();
@@ -904,7 +794,12 @@ mod tests {
 
     #[test]
     fn clone_into_owned_preserves_data() {
-        let init = KeyExchangeInit::new(42, [1u8; 32], [1, 2, 3, 4, 5, 6].into());
+        let init = KeyExchangeInit::new_unsigned(
+            DhGroup::X25519,
+            42,
+            [1u8; 32].to_vec(),
+            [1, 2, 3, 4, 5, 6].into(),
+        );
         let bytes: Vec<u8> = (&init).into();
         let parsed = KeyExchangeInit::try_from(&bytes[..]).expect("parse");
         let owned = parsed.clone_into_owned();

--- a/node_lib/src/messages/auth/mod.rs
+++ b/node_lib/src/messages/auth/mod.rs
@@ -1,0 +1,71 @@
+pub mod key_exchange;
+pub mod session_terminated;
+
+use crate::error::NodeError;
+pub use key_exchange::{KeyExchangeInit, KeyExchangeReply};
+pub use session_terminated::SessionTerminated;
+
+#[derive(Debug)]
+pub enum Auth<'a> {
+    /// OBU initiates a key negotiation with the server.
+    KeyExchangeInit(KeyExchangeInit<'a>),
+    /// Server replies to a key negotiation initiated by the OBU.
+    KeyExchangeReply(KeyExchangeReply<'a>),
+    /// Server revokes an OBU's session; target OBU must re-key immediately.
+    SessionTerminated(SessionTerminated<'a>),
+}
+
+impl<'a> Auth<'a> {
+    /// Wire size of the auth payload in bytes (excludes the 1-byte type tag).
+    pub fn wire_size(&self) -> usize {
+        match self {
+            Auth::KeyExchangeInit(k) => k.wire_size(),
+            Auth::KeyExchangeReply(k) => k.wire_size(),
+            Auth::SessionTerminated(s) => s.wire_size(),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Auth<'a> {
+    type Error = NodeError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        let next = value.get(1..).ok_or_else(|| NodeError::BufferTooShort {
+            expected: 2,
+            actual: value.len(),
+        })?;
+
+        match value.first() {
+            Some(0u8) => Ok(Self::KeyExchangeInit(next.try_into()?)),
+            Some(1u8) => Ok(Self::KeyExchangeReply(next.try_into()?)),
+            Some(2u8) => Ok(Self::SessionTerminated(next.try_into()?)),
+            _ => Err(NodeError::ParseError(
+                "Invalid auth message type".to_string(),
+            )),
+        }
+    }
+}
+
+impl<'a> From<&Auth<'a>> for Vec<u8> {
+    fn from(value: &Auth<'a>) -> Self {
+        let mut buf = Vec::with_capacity(64);
+        match value {
+            Auth::KeyExchangeInit(k) => {
+                buf.push(0u8);
+                let ke_bytes: Vec<u8> = k.into();
+                buf.extend_from_slice(&ke_bytes);
+            }
+            Auth::KeyExchangeReply(k) => {
+                buf.push(1u8);
+                let ke_bytes: Vec<u8> = k.into();
+                buf.extend_from_slice(&ke_bytes);
+            }
+            Auth::SessionTerminated(s) => {
+                buf.push(2u8);
+                let st_bytes: Vec<u8> = s.into();
+                buf.extend_from_slice(&st_bytes);
+            }
+        }
+        buf
+    }
+}

--- a/node_lib/src/messages/auth/session_terminated.rs
+++ b/node_lib/src/messages/auth/session_terminated.rs
@@ -1,14 +1,16 @@
 use mac_address::MacAddress;
 use std::borrow::Cow;
 
-/// A `SessionTerminated` control message sent by the server (via RSU relay) to
+use crate::crypto::SigningAlgorithm;
+
+/// A `SessionTerminated` auth message sent by the server (via RSU relay) to
 /// notify an OBU that its session has been revoked by the server administrator.
 ///
 /// The target OBU must clear its DH session key and immediately re-initiate a
 /// new key exchange.  Intermediate OBUs forward this message toward the target
 /// using the embedded `target` MAC.
 ///
-/// Binary layout (inside the Control payload, after the type byte):
+/// Binary layout (inside the Auth payload, after the type byte):
 /// ```text
 /// Unsigned:  [TARGET_OBU_MAC 6B]
 /// Signed:    [TARGET_OBU_MAC 6B][TIMESTAMP_SECS 8B][NONCE 8B]
@@ -17,7 +19,7 @@ use std::borrow::Cow;
 ///
 /// The signed payload (what the server signs) is:
 /// ```text
-/// [CONTROL_TYPE_BYTE=0x04][TARGET_OBU_MAC 6B][TIMESTAMP_SECS 8B][NONCE 8B]
+/// [AUTH_TYPE_BYTE=0x02][TARGET_OBU_MAC 6B][TIMESTAMP_SECS 8B][NONCE 8B]
 /// ```
 ///
 /// **Replay prevention**: Two complementary mechanisms:
@@ -31,6 +33,9 @@ pub const VALIDITY_SECS: u64 = 60;
 /// Clock skew tolerance: accept messages up to this many seconds in the future.
 pub const CLOCK_SKEW_TOLERANCE_SECS: u64 = 5;
 
+/// Wire type byte prepended to the signed payload; matches Auth::SessionTerminated sub-ID.
+const SIGNED_PAYLOAD_TYPE_BYTE: u8 = 0x02;
+
 #[derive(Debug, Clone)]
 pub struct SessionTerminated<'a> {
     target: Cow<'a, [u8]>,
@@ -38,7 +43,7 @@ pub struct SessionTerminated<'a> {
     timestamp_secs: Option<u64>,
     /// 8-byte server-generated random nonce.
     nonce: Option<[u8; 8]>,
-    /// Signature algorithm ID (same constants as KeyExchange).
+    /// Wire-format signature algorithm byte, if signed.
     sig_algo_id: Option<u8>,
     /// Raw signature bytes from the server.
     signature: Option<Cow<'a, [u8]>>,
@@ -61,16 +66,31 @@ impl<'a> SessionTerminated<'a> {
         target: MacAddress,
         timestamp_secs: u64,
         nonce: [u8; 8],
-        sig_algo_id: u8,
+        sig_algo: SigningAlgorithm,
         signature: Vec<u8>,
     ) -> Self {
         Self {
             target: Cow::Owned(target.bytes().to_vec()),
             timestamp_secs: Some(timestamp_secs),
             nonce: Some(nonce),
-            sig_algo_id: Some(sig_algo_id),
+            sig_algo_id: Some(sig_algo.wire_id()),
             signature: Some(Cow::Owned(signature)),
         }
+    }
+
+    /// Build the canonical byte payload that the server signs and the OBU verifies.
+    ///
+    /// `[SIGNED_PAYLOAD_TYPE_BYTE][TARGET_OBU_MAC 6B][TIMESTAMP_SECS 8B][NONCE 8B]`
+    pub fn build_signed_payload(
+        target: MacAddress,
+        timestamp_secs: u64,
+        nonce: [u8; 8],
+    ) -> Vec<u8> {
+        let mut payload = vec![SIGNED_PAYLOAD_TYPE_BYTE];
+        payload.extend_from_slice(&target.bytes());
+        payload.extend_from_slice(&timestamp_secs.to_be_bytes());
+        payload.extend_from_slice(&nonce);
+        payload
     }
 
     pub fn target(&self) -> MacAddress {
@@ -89,8 +109,9 @@ impl<'a> SessionTerminated<'a> {
         self.nonce.as_ref()
     }
 
-    pub fn sig_algo_id(&self) -> Option<u8> {
-        self.sig_algo_id
+    /// Returns the signing algorithm, or `None` if unsigned or unrecognised wire ID.
+    pub fn signing_algorithm(&self) -> Option<SigningAlgorithm> {
+        self.sig_algo_id.and_then(SigningAlgorithm::from_wire_id)
     }
 
     pub fn signature(&self) -> Option<&[u8]> {
@@ -212,7 +233,8 @@ mod tests {
         let ts: u64 = 1_700_000_000;
         let nonce = [0xAAu8; 8];
         let sig = vec![0xBBu8; 64];
-        let msg = SessionTerminated::new_signed(mac, ts, nonce, 0x01, sig.clone());
+        let msg =
+            SessionTerminated::new_signed(mac, ts, nonce, SigningAlgorithm::Ed25519, sig.clone());
         let bytes: Vec<u8> = (&msg).into();
         // 6 (mac) + 8 (ts) + 8 (nonce) + 1 (algo) + 2 (len) + 64 (sig) = 89
         assert_eq!(bytes.len(), 89);
@@ -220,7 +242,7 @@ mod tests {
         assert_eq!(parsed.target(), mac);
         assert_eq!(parsed.timestamp_secs(), Some(ts));
         assert_eq!(parsed.nonce(), Some(&nonce));
-        assert_eq!(parsed.sig_algo_id(), Some(0x01));
+        assert_eq!(parsed.signing_algorithm(), Some(SigningAlgorithm::Ed25519));
         assert_eq!(parsed.signature(), Some(sig.as_slice()));
     }
 
@@ -233,6 +255,19 @@ mod tests {
     fn signed_too_short_returns_error() {
         // 6 mac bytes + partial signed extension (< 25 total)
         assert!(SessionTerminated::try_from(&[0u8; 10][..]).is_err());
+    }
+
+    #[test]
+    fn build_signed_payload_format() {
+        let mac: MacAddress = [1, 2, 3, 4, 5, 6].into();
+        let ts: u64 = 1_700_000_000;
+        let nonce = [0xAAu8; 8];
+        let payload = SessionTerminated::build_signed_payload(mac, ts, nonce);
+        assert_eq!(payload.len(), 1 + 6 + 8 + 8);
+        assert_eq!(payload[0], SIGNED_PAYLOAD_TYPE_BYTE);
+        assert_eq!(&payload[1..7], &mac.bytes());
+        assert_eq!(&payload[7..15], &ts.to_be_bytes());
+        assert_eq!(&payload[15..23], &nonce);
     }
 
     #[test]
@@ -253,7 +288,8 @@ mod tests {
         let ts: u64 = 1_700_000_001;
         let nonce = [0x55u8; 8];
         let sig = vec![0xCCu8; 64];
-        let original = SessionTerminated::new_signed(mac, ts, nonce, 0x01, sig.clone());
+        let original =
+            SessionTerminated::new_signed(mac, ts, nonce, SigningAlgorithm::Ed25519, sig.clone());
         let bytes: Vec<u8> = (&original).into();
         let borrowed = SessionTerminated::try_from(bytes.as_slice()).unwrap();
         let owned = borrowed.clone_into_owned();

--- a/node_lib/src/messages/control/mod.rs
+++ b/node_lib/src/messages/control/mod.rs
@@ -1,20 +1,12 @@
 pub mod heartbeat;
-pub mod key_exchange;
-pub mod session_terminated;
 
 use crate::error::NodeError;
 use heartbeat::{Heartbeat, HeartbeatReply};
-use key_exchange::{KeyExchangeInit, KeyExchangeReply};
-pub use session_terminated::SessionTerminated;
 
 #[derive(Debug)]
 pub enum Control<'a> {
     Heartbeat(Heartbeat<'a>),
     HeartbeatReply(HeartbeatReply<'a>),
-    KeyExchangeInit(KeyExchangeInit<'a>),
-    KeyExchangeReply(KeyExchangeReply<'a>),
-    /// Session revocation notice from server: target OBU must re-key immediately.
-    SessionTerminated(SessionTerminated<'a>),
 }
 
 impl<'a> Control<'a> {
@@ -23,9 +15,6 @@ impl<'a> Control<'a> {
         match self {
             Control::Heartbeat(hb) => hb.wire_size(),
             Control::HeartbeatReply(hbr) => hbr.wire_size(),
-            Control::KeyExchangeInit(k) => k.wire_size(),
-            Control::KeyExchangeReply(k) => k.wire_size(),
-            Control::SessionTerminated(s) => s.wire_size(),
         }
     }
 }
@@ -42,9 +31,6 @@ impl<'a> TryFrom<&'a [u8]> for Control<'a> {
         match value.first() {
             Some(0u8) => Ok(Self::Heartbeat(next.try_into()?)),
             Some(1u8) => Ok(Self::HeartbeatReply(next.try_into()?)),
-            Some(2u8) => Ok(Self::KeyExchangeInit(next.try_into()?)),
-            Some(3u8) => Ok(Self::KeyExchangeReply(next.try_into()?)),
-            Some(4u8) => Ok(Self::SessionTerminated(next.try_into()?)),
             _ => Err(NodeError::ParseError(
                 "Invalid control message type".to_string(),
             )),
@@ -66,21 +52,6 @@ impl<'a> From<&Control<'a>> for Vec<u8> {
                 let hbr_bytes: Vec<u8> = c.into();
                 buf.extend_from_slice(&hbr_bytes);
             }
-            Control::KeyExchangeInit(c) => {
-                buf.push(2u8);
-                let ke_bytes: Vec<u8> = c.into();
-                buf.extend_from_slice(&ke_bytes);
-            }
-            Control::KeyExchangeReply(c) => {
-                buf.push(3u8);
-                let ke_bytes: Vec<u8> = c.into();
-                buf.extend_from_slice(&ke_bytes);
-            }
-            Control::SessionTerminated(c) => {
-                buf.push(4u8);
-                let st_bytes: Vec<u8> = c.into();
-                buf.extend_from_slice(&st_bytes);
-            }
         }
         buf
     }
@@ -100,21 +71,6 @@ impl<'a> From<&Control<'a>> for Vec<Vec<u8>> {
                 let mut result = vec![vec![1u8]];
                 let more: Vec<Vec<u8>> = c.into();
                 result.extend(more);
-                result
-            }
-            Control::KeyExchangeInit(c) => {
-                let mut result = vec![vec![2u8]];
-                result.push(c.into());
-                result
-            }
-            Control::KeyExchangeReply(c) => {
-                let mut result = vec![vec![3u8]];
-                result.push(c.into());
-                result
-            }
-            Control::SessionTerminated(c) => {
-                let mut result = vec![vec![4u8]];
-                result.push(c.into());
                 result
             }
         }

--- a/node_lib/src/messages/mod.rs
+++ b/node_lib/src/messages/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod control;
 pub mod data;
 pub mod message;

--- a/node_lib/src/messages/packet_type.rs
+++ b/node_lib/src/messages/packet_type.rs
@@ -1,10 +1,11 @@
-use super::{control::Control, data::Data};
+use super::{auth::Auth, control::Control, data::Data};
 use crate::error::NodeError;
 
 #[derive(Debug)]
 pub enum PacketType<'a> {
     Control(Control<'a>),
     Data(Data<'a>),
+    Auth(Auth<'a>),
 }
 
 impl<'a> PacketType<'a> {
@@ -13,6 +14,7 @@ impl<'a> PacketType<'a> {
         1 + match self {
             PacketType::Control(c) => 1 + c.wire_size(),
             PacketType::Data(d) => 1 + d.wire_size(),
+            PacketType::Auth(a) => 1 + a.wire_size(),
         }
     }
 }
@@ -29,6 +31,7 @@ impl<'a> TryFrom<&'a [u8]> for PacketType<'a> {
         match value.first() {
             Some(0u8) => Ok(Self::Control(next.try_into()?)),
             Some(1u8) => Ok(Self::Data(next.try_into()?)),
+            Some(2u8) => Ok(Self::Auth(next.try_into()?)),
             _ => Err(NodeError::ParseError(
                 "Invalid packet type identifier".to_string(),
             )),
@@ -49,6 +52,11 @@ impl<'a> From<&PacketType<'a>> for Vec<u8> {
                 buf.push(1u8);
                 let data_bytes: Vec<u8> = d.into();
                 buf.extend_from_slice(&data_bytes);
+            }
+            PacketType::Auth(a) => {
+                buf.push(2u8);
+                let auth_bytes: Vec<u8> = a.into();
+                buf.extend_from_slice(&auth_bytes);
             }
         }
         buf
@@ -71,6 +79,12 @@ impl<'a> From<&PacketType<'a>> for Vec<Vec<u8>> {
                 result.extend(more);
                 result
             }
+            PacketType::Auth(a) => {
+                let mut result = vec![vec![2u8]];
+                let auth_bytes: Vec<u8> = a.into();
+                result.push(auth_bytes);
+                result
+            }
         }
     }
 }
@@ -81,7 +95,7 @@ mod tests {
 
     #[test]
     fn packet_type_invalid_first_byte_is_error() {
-        let pkt = [2u8];
+        let pkt = [3u8];
         let res = PacketType::try_from(&pkt[..]);
         assert!(res.is_err());
     }

--- a/obu_lib/src/control/mod.rs
+++ b/obu_lib/src/control/mod.rs
@@ -12,64 +12,19 @@ use crate::args::ObuArgs;
 use anyhow::{anyhow, Result};
 use common::tun::Tun;
 use common::{device::Device, network_interface::NetworkInterface};
-use dh_key_store::DhKeyStore;
 use mac_address::MacAddress;
 use node::ReplyType;
-use node_lib::control::client_cache::ClientCache;
-use node_lib::crypto::{sig_algo_from_id, CryptoConfig, SigningAlgorithm, SigningKeypair};
 use node_lib::messages::{
-    control::{
-        key_exchange::{KeyExchangeInit, KeyExchangeReply},
-        session_terminated::SessionTerminated,
-        Control,
-    },
-    data::{Data, ToUpstream},
-    message::Message,
-    packet_type::PacketType,
+    auth::Auth, control::Control, data::Data, message::Message, packet_type::PacketType,
 };
 use routing::Routing;
-use session::Session;
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex, RwLock};
-use tokio::sync::Notify;
-use tokio::time::{Duration, Instant};
+use session::{CryptoState, Session};
+use std::sync::Arc;
+use tokio::time::Instant;
 use tracing::Instrument;
 
 // Re-export type aliases for cleaner code
 use node_lib::{Shared, SharedDevice, SharedTun};
-
-type SharedKeyStore = Arc<RwLock<DhKeyStore>>;
-type RevocationNonceCache = Arc<Mutex<VecDeque<([u8; 8], std::time::Instant)>>>;
-
-/// Action to take when a DH key exchange is needed.
-#[derive(Debug, Clone, Copy)]
-enum DhAction {
-    /// No pending exchange exists — start a fresh one.
-    Initiate,
-    /// A pending exchange timed out — re-use its retry counter.
-    Reinitiate,
-}
-
-/// Decode a hex string of any length into bytes. Returns `None` on invalid hex.
-fn decode_hex(s: &str) -> Option<Vec<u8>> {
-    if !s.len().is_multiple_of(2) {
-        return None;
-    }
-    (0..s.len() / 2)
-        .map(|i| u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok())
-        .collect()
-}
-
-fn encode_hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-/// Virtual MAC used to key the DH store for the server tunnel.
-/// The OBU negotiates keys with the server (not peers), so we use a
-/// fixed sentinel MAC as the store key.
-fn server_virtual_mac() -> MacAddress {
-    MacAddress::new([0, 0, 0, 0, 0, 0])
-}
 
 pub struct Obu {
     args: ObuArgs,
@@ -78,29 +33,7 @@ pub struct Obu {
     device: SharedDevice,
     session: Arc<Session>,
     node_name: String,
-    dh_key_store: SharedKeyStore,
-    crypto_config: CryptoConfig,
-    /// Ed25519 identity keypair used to sign outgoing DH messages.
-    /// Present only when `enable_dh_signatures` is `true`.
-    signing_keypair: Option<Arc<SigningKeypair>>,
-    /// Wakes the DH re-keying task immediately when a `SessionTerminated` notice
-    /// is received, bypassing the normal re-key interval sleep.
-    rekey_notify: Arc<Notify>,
-    /// Time-bounded cache of recently-seen `SessionTerminated` nonces.
-    /// Each entry is `(nonce, received_at)`. Entries older than `VALIDITY_SECS`
-    /// are pruned on each check. Because eviction is time-driven (not count-driven)
-    /// the cache never grows stale: old nonces expire along with the messages that
-    /// carried them, so there is no fixed-size window that an attacker could outlast.
-    seen_revocation_nonces: RevocationNonceCache,
-    /// Downstream client cache for relay-mode operation.
-    ///
-    /// When this OBU acts as an intermediate relay (forwarding a `KeyExchangeInit`
-    /// from a downstream OBU up toward an RSU), it records the mapping
-    /// `ke_init.sender() → msg.from()` here.  On the return path, when a
-    /// `KeyExchangeReply` arrives destined for a downstream OBU, this cache is
-    /// consulted first so the reply can be forwarded immediately — even before the
-    /// heartbeat-reply-based downstream routing table has been populated.
-    downstream_client_cache: Arc<ClientCache>,
+    crypto: Arc<CryptoState>,
 }
 
 impl Obu {
@@ -113,52 +46,17 @@ impl Obu {
         let _span = tracing::info_span!("node", name = %node_name).entered();
 
         let boot = Instant::now();
-        let routing = Arc::new(RwLock::new(Routing::new(&args, &boot)?));
+        let routing = Arc::new(std::sync::RwLock::new(Routing::new(&args, &boot)?));
+        let crypto = Arc::new(CryptoState::new(&args)?);
 
-        let crypto_config = CryptoConfig {
-            cipher: args.obu_params.cipher,
-            kdf: args.obu_params.kdf,
-            dh_group: args.obu_params.dh_group,
-            signing_algorithm: args.obu_params.signing_algorithm,
-        };
-
-        let signing_algo = args.obu_params.signing_algorithm;
-        let signing_keypair = if args.obu_params.enable_dh_signatures {
-            let kp = if let Some(ref hex_seed) = args.obu_params.signing_key_seed {
-                let seed = node_lib::crypto::decode_hex_32(hex_seed).ok_or_else(|| {
-                    anyhow!("signing_key_seed must be exactly 64 hex characters (32 bytes)")
-                })?;
-                SigningKeypair::from_seed(signing_algo, seed)
-            } else {
-                SigningKeypair::generate(signing_algo)
-            };
-            let pubkey_hex = encode_hex(&kp.verifying_key_bytes());
-            tracing::info!(
-                signing_pubkey = %pubkey_hex,
-                "DH signing enabled — register this public key in the server's \
-                 dh_signing_allowlist to enforce PKI authentication"
-            );
-            Some(Arc::new(kp))
-        } else {
-            None
-        };
-
-        let dh_key_store = Arc::new(RwLock::new(DhKeyStore::new(crypto_config)));
-        let rekey_notify = Arc::new(Notify::new());
-        let seen_revocation_nonces = Arc::new(Mutex::new(VecDeque::new()));
         let obu = Arc::new(Self {
-            args,
             routing,
             tun: tun.clone(),
             device,
             session: Session::new(tun).into(),
             node_name,
-            dh_key_store,
-            crypto_config,
-            signing_keypair,
-            rekey_notify,
-            seen_revocation_nonces,
-            downstream_client_cache: Arc::new(ClientCache::new()),
+            crypto,
+            args,
         });
 
         tracing::info!(
@@ -167,14 +65,6 @@ impl Obu {
             mtu = obu.args.mtu,
             hello_history = obu.args.obu_params.hello_history,
             cached_candidates = obu.args.obu_params.cached_candidates,
-            encryption = obu.args.obu_params.enable_encryption,
-            cipher = %obu.crypto_config.cipher,
-            dh_enabled = obu.args.obu_params.enable_encryption,
-            dh_group = %obu.crypto_config.dh_group,
-            kdf = %obu.crypto_config.kdf,
-            dh_rekey_interval_ms = obu.args.obu_params.dh_rekey_interval_ms,
-            dh_key_lifetime_ms = obu.args.obu_params.dh_key_lifetime_ms,
-            dh_reply_timeout_ms = obu.args.obu_params.dh_reply_timeout_ms,
             "OBU initialized"
         );
         if !obu.args.obu_params.enable_encryption {
@@ -189,17 +79,22 @@ impl Obu {
                  Set --enable-dh-signatures to prevent MITM key substitution."
             );
         }
-        obu.session_task()?;
+        CryptoState::start_session_task(
+            obu.crypto.clone(),
+            obu.session.clone(),
+            obu.tun.clone(),
+            obu.device.clone(),
+            obu.routing.clone(),
+            obu.node_name.clone(),
+        )?;
         Obu::wire_traffic_task(obu.clone())?;
         if obu.args.obu_params.enable_encryption {
-            tracing::info!(
-                cipher = %obu.crypto_config.cipher,
-                kdf = %obu.crypto_config.kdf,
-                dh_group = %obu.crypto_config.dh_group,
-                rekey_interval_ms = obu.args.obu_params.dh_rekey_interval_ms,
-                "Starting DH re-keying task"
-            );
-            Obu::dh_rekey_task(obu.clone())?;
+            CryptoState::start_dh_rekey_task(
+                obu.crypto.clone(),
+                obu.device.clone(),
+                obu.routing.clone(),
+                obu.node_name.clone(),
+            )?;
         }
         Ok(obu)
     }
@@ -227,10 +122,7 @@ impl Obu {
 
     /// Check whether a DH session with the server has been established.
     pub fn has_dh_session(&self) -> bool {
-        self.dh_key_store
-            .read()
-            .expect("dh key store read lock poisoned")
-            .has_established_key(server_virtual_mac())
+        self.crypto.has_dh_session()
     }
 
     /// Return the cached upstream Route if present (hops, mac, latency).
@@ -273,236 +165,17 @@ impl Obu {
     /// Return the established DH session info: `(key_id, age_secs)`.
     /// Returns `None` when no session has been established yet.
     pub fn get_dh_session_info(&self) -> Option<(u32, u64)> {
-        self.dh_key_store
-            .read()
-            .expect("dh key store read lock poisoned")
-            .get_session_info(server_virtual_mac())
+        self.crypto.get_dh_session_info()
     }
 
     /// Immediately trigger a DH re-key exchange, bypassing the normal interval.
-    ///
-    /// Clears the current established session (if any) and wakes the re-keying
-    /// task so it initiates a new key exchange on the next loop iteration.
     pub fn trigger_rekey(&self) {
-        {
-            let mut store = self
-                .dh_key_store
-                .write()
-                .expect("dh key store write lock poisoned");
-            store.clear_session(server_virtual_mac());
-        }
-        self.rekey_notify.notify_one();
-        tracing::info!("DH re-key triggered manually via admin interface");
+        self.crypto.trigger_rekey();
     }
 
     /// Return whether a pending DH exchange is in progress.
     pub fn has_dh_pending(&self) -> bool {
-        self.dh_key_store
-            .read()
-            .expect("dh key store read lock poisoned")
-            .has_pending(server_virtual_mac())
-    }
-
-    /// Periodic DH re-keying task.
-    ///
-    /// Normally wakes every `dh_rekey_interval_ms` to check whether a new key
-    /// exchange is needed.  The `rekey_notify` Notify bypasses the sleep so the
-    /// task reacts immediately when a `SessionTerminated` notice clears the key.
-    fn dh_rekey_task(obu: Arc<Self>) -> Result<()> {
-        let rekey_interval = Duration::from_millis(obu.args.obu_params.dh_rekey_interval_ms);
-        let key_lifetime_ms = obu.args.obu_params.dh_key_lifetime_ms;
-        let reply_timeout_ms = obu.args.obu_params.dh_reply_timeout_ms;
-        let node_name = obu.node_name.clone();
-        let rekey_notify = obu.rekey_notify.clone();
-
-        let span = tracing::info_span!("node", name = %node_name);
-        tokio::task::spawn(
-            async move {
-                // Initial delay to allow routing to establish
-                tokio::time::sleep(Duration::from_millis(500)).await;
-                tracing::info!(
-                    upstream = ?obu.cached_upstream_mac(),
-                    "DH rekey task starting (initial delay elapsed)"
-                );
-
-                loop {
-                    if let Some(mut upstream_mac) = obu.cached_upstream_mac() {
-                        // Use server_virtual_mac() for key store lookups — the key
-                        // is with the server, not with a specific RSU/peer.
-                        let needs_exchange = {
-                            let store = obu
-                                .dh_key_store
-                                .read()
-                                .expect("dh key store read lock poisoned");
-                            let no_key = !store.has_established_key(server_virtual_mac());
-                            let expired = store.is_key_expired(server_virtual_mac(), key_lifetime_ms);
-                            if expired {
-                                tracing::debug!(
-                                    via = %upstream_mac,
-                                    lifetime_ms = key_lifetime_ms,
-                                    "Server DH key expired, initiating re-key"
-                                );
-                            }
-                            no_key || expired
-                        };
-
-                        if needs_exchange {
-                            // Determine what action to take:
-                            // - If no pending exchange, initiate a new one
-                            // - If pending exchange timed out, re-initiate (preserving retry count)
-                            //   After 3 consecutive timeouts, failover to the next-best RSU candidate
-                            //   so that an OBU stuck at the edge of range doesn't retry forever
-                            //   through an RSU with high packet loss.
-                            // - If pending exchange still in progress, wait
-                            let action: Option<DhAction> = {
-                                let store = obu
-                                    .dh_key_store
-                                    .read()
-                                    .expect("dh key store read lock poisoned");
-                                if !store.has_pending(server_virtual_mac()) {
-                                    Some(DhAction::Initiate)
-                                } else if store.is_pending_timed_out(server_virtual_mac(), reply_timeout_ms) {
-                                    let retries = store.pending_retries(server_virtual_mac()).unwrap_or(0);
-                                    // After 3 timeouts through the same RSU, rotate to the next
-                                    // candidate.  The reinitiation below will use the new upstream.
-                                    if retries >= 3 {
-                                        if let Some(new_upstream) = obu
-                                            .routing
-                                            .read()
-                                            .expect("routing read lock")
-                                            .failover_cached_upstream()
-                                        {
-                                            tracing::warn!(
-                                                old_via = %upstream_mac,
-                                                new_via = %new_upstream,
-                                                retry = retries + 1,
-                                                "DH timeout threshold reached, failing over to next RSU candidate"
-                                            );
-                                            upstream_mac = new_upstream;
-                                        }
-                                    } else {
-                                        tracing::warn!(
-                                            via = %upstream_mac,
-                                            retry = retries + 1,
-                                            "Server DH reply timed out, re-initiating (no session — packets will be dropped until established)"
-                                        );
-                                    }
-                                    Some(DhAction::Reinitiate)
-                                } else {
-                                    None // still pending, wait
-                                }
-                            };
-
-                            if let Some(action) = action {
-                                let (key_id, pub_key) = {
-                                    let mut store = obu
-                                        .dh_key_store
-                                        .write()
-                                        .expect("dh key store write lock poisoned");
-                                    match action {
-                                        DhAction::Reinitiate => store.reinitiate_exchange(server_virtual_mac()),
-                                        DhAction::Initiate => store.initiate_exchange(server_virtual_mac()),
-                                    }
-                                };
-
-                                let our_mac = obu.device.mac_address();
-                                let algo_id = match obu.crypto_config.dh_group {
-                                    node_lib::crypto::DhGroup::X25519 => {
-                                        node_lib::messages::control::key_exchange::KE_ALGO_X25519
-                                    }
-                                    node_lib::crypto::DhGroup::MlKem768 => {
-                                        node_lib::messages::control::key_exchange::KE_ALGO_ML_KEM_768
-                                    }
-                                };
-                                let init_msg = if let Some(ref kp) = obu.signing_keypair {
-                                    let sig_algo_id = match kp.signing_algorithm() {
-                                        SigningAlgorithm::Ed25519 => {
-                                            node_lib::messages::control::key_exchange::SIG_ALGO_ED25519
-                                        }
-                                        SigningAlgorithm::MlDsa65 => {
-                                            node_lib::messages::control::key_exchange::SIG_ALGO_ML_DSA_65
-                                        }
-                                    };
-                                    let unsigned = KeyExchangeInit::new_raw(
-                                        algo_id, key_id, pub_key.clone(), our_mac,
-                                        None, None, None,
-                                    );
-                                    let base = unsigned.base_payload();
-                                    let sig = kp.sign(&base);
-                                    let spk = kp.verifying_key_bytes();
-                                    KeyExchangeInit::new_raw(
-                                        algo_id, key_id, pub_key, our_mac,
-                                        Some(sig_algo_id), Some(spk), Some(sig),
-                                    )
-                                } else {
-                                    KeyExchangeInit::new_raw(
-                                        algo_id, key_id, pub_key, our_mac,
-                                        None, None, None,
-                                    )
-                                };
-                                // Send to upstream RSU — it will relay to server
-                                let msg = Message::new(
-                                    our_mac,
-                                    upstream_mac,
-                                    PacketType::Control(Control::KeyExchangeInit(init_msg)),
-                                );
-                                let wire: Vec<u8> = (&msg).into();
-
-                                if let Err(e) = obu.device.send(&wire).await {
-                                    tracing::warn!(
-                                        error = %e,
-                                        via = %upstream_mac,
-                                        key_id = key_id,
-                                        "Failed to send DH KeyExchangeInit (for server)"
-                                    );
-                                } else {
-                                    tracing::info!(
-                                        via = %upstream_mac,
-                                        key_id = key_id,
-                                        mode = ?action,
-                                        dh_group = %obu.crypto_config.dh_group,
-                                        "Sent DH KeyExchangeInit upstream"
-                                    );
-                                }
-                            }
-                        }
-                    } else {
-                        tracing::warn!(
-                            "DH rekey task: no upstream RSU cached yet — skipping exchange until next wakeup"
-                        );
-                    }
-
-                    // Wait for either the normal rekey interval or an early wake-up
-                    // triggered by receiving a SessionTerminated notice.
-                    // When a DH exchange is in-flight, use a short sleep equal to
-                    // reply_timeout_ms so we wake promptly to detect the timeout and
-                    // retransmit, rather than waiting the full 12-hour rekey interval
-                    // before retrying a failed initial exchange.
-                    // When no upstream was available, also use a short retry so we
-                    // attempt again as soon as the first heartbeat populates the routing
-                    // table (typically within one hello_periodicity).
-                    let no_upstream = obu.cached_upstream_mac().is_none();
-                    let exchange_pending = obu
-                        .dh_key_store
-                        .read()
-                        .map(|g| g.has_pending(server_virtual_mac()))
-                        .unwrap_or(false);
-                    let sleep_duration = if exchange_pending || no_upstream {
-                        Duration::from_millis(reply_timeout_ms)
-                    } else {
-                        rekey_interval
-                    };
-                    tokio::select! {
-                        _ = tokio::time::sleep(sleep_duration) => {}
-                        _ = rekey_notify.notified() => {
-                            tracing::debug!("DH rekey task woken early by SessionTerminated");
-                        }
-                    }
-                }
-            }
-            .instrument(span),
-        );
-        Ok(())
+        self.crypto.has_dh_pending()
     }
 
     fn wire_traffic_task(obu: Arc<Self>) -> Result<()> {
@@ -570,97 +243,6 @@ impl Obu {
         Ok(())
     }
 
-    fn session_task(&self) -> Result<()> {
-        let routing = self.routing.clone();
-        let session = self.session.clone();
-        let device = self.device.clone();
-        let tun = self.tun.clone();
-        let routing_handle = routing.clone();
-        let enable_encryption = self.args.obu_params.enable_encryption;
-        let cipher = self.crypto_config.cipher;
-        let dh_key_store = self.dh_key_store.clone();
-        let node_name = self.node_name.clone();
-
-        let span = tracing::info_span!("node", name = %node_name);
-        tokio::task::spawn(
-            async move {
-                loop {
-                    let devicec = device.clone();
-                    let routing_for_closure = routing_handle.clone();
-                    let routing_for_handle = routing_handle.clone();
-                    let dh_store = dh_key_store.clone();
-                    let messages = session
-                        .process(|x, size| async move {
-                            let y: &[u8] = &x[..size];
-                            let Some(upstream) = routing_for_closure
-                                .read()
-                                .expect("routing table read lock poisoned in heartbeat task")
-                                .get_route_to(None)
-                            else {
-                                return Ok(None);
-                            };
-
-                            let payload_data = if enable_encryption {
-                                // Always use server_virtual_mac() — the key is
-                                // negotiated with the server, not the RSU.
-                                let dh_store_guard = dh_store
-                                    .read()
-                                    .expect("dh key store read lock poisoned");
-                                let dh_key = dh_store_guard.get_key(server_virtual_mac());
-                                let Some(key) = dh_key else {
-                                    tracing::debug!(
-                                        size = y.len(),
-                                        cipher = %cipher,
-                                        "No DH session established with server, dropping upstream frame"
-                                    );
-                                    return Ok(None);
-                                };
-                                match node_lib::crypto::encrypt_with_config(cipher, y, key) {
-                                    Ok(encrypted_data) => encrypted_data,
-                                    Err(e) => {
-                                        tracing::error!(
-                                            size = y.len(),
-                                            cipher = %cipher,
-                                            error = %e,
-                                            "Failed to encrypt upstream frame"
-                                        );
-                                        return Ok(None);
-                                    }
-                                }
-                            } else {
-                                y.to_vec()
-                            };
-
-                            let origin = devicec.mac_address();
-                            let mut wire = Vec::with_capacity(24 + payload_data.len());
-                            let tu = ToUpstream::new(origin, &payload_data);
-                            Message::serialize_upstream_forward_into(
-                                &tu,
-                                origin,
-                                upstream.mac,
-                                &mut wire,
-                            );
-                            let outgoing = vec![ReplyType::WireFlat(wire)];
-                            Ok(Some(outgoing))
-                        })
-                        .await;
-
-                    if let Ok(Some(messages)) = messages {
-                        let _ = node::handle_messages(
-                            messages,
-                            &tun,
-                            &device,
-                            Some(routing_for_handle.clone()),
-                        )
-                        .await;
-                    }
-                }
-            }
-            .instrument(span),
-        );
-        Ok(())
-    }
-
     async fn handle_msg(&self, msg: &Message<'_>) -> Result<Option<Vec<ReplyType>>> {
         match msg.get_packet_type() {
             PacketType::Data(Data::Upstream(buf)) => {
@@ -691,37 +273,8 @@ impl Obu {
                 let is_for_us =
                     destination == self.device.mac_address() || destination.bytes()[0] & 0x1 != 0;
                 if is_for_us {
-                    let payload_data = if self.args.obu_params.enable_encryption {
-                        // Always use server_virtual_mac() — the key is
-                        // negotiated with the server, not the sender RSU.
-                        let dh_key_store = self
-                            .dh_key_store
-                            .read()
-                            .expect("dh key store read lock poisoned");
-                        let dh_key = dh_key_store.get_key(server_virtual_mac());
-                        let cipher = self.crypto_config.cipher;
-                        let Some(key) = dh_key else {
-                            tracing::debug!(
-                                size = buf.data().len(),
-                                cipher = %cipher,
-                                "No DH session established with server, dropping downstream frame"
-                            );
-                            return Ok(None);
-                        };
-                        match node_lib::crypto::decrypt_with_config(cipher, buf.data(), key) {
-                            Ok(decrypted_data) => decrypted_data,
-                            Err(e) => {
-                                tracing::warn!(
-                                    size = buf.data().len(),
-                                    cipher = %cipher,
-                                    error = %e,
-                                    "Failed to decrypt downstream frame, dropping"
-                                );
-                                return Ok(None);
-                            }
-                        }
-                    } else {
-                        buf.data().to_vec()
+                    let Some(payload_data) = self.crypto.decrypt_downstream(buf.data()) else {
+                        return Ok(None);
                     };
                     return Ok(Some(vec![ReplyType::TapFlat(payload_data)]));
                 }
@@ -755,433 +308,17 @@ impl Obu {
                 .write()
                 .expect("routing table write lock poisoned during heartbeat reply handling")
                 .handle_heartbeat_reply(msg, self.device.mac_address()),
-            PacketType::Control(Control::KeyExchangeInit(ke_init)) => {
-                self.handle_key_exchange_init(ke_init, msg)
-            }
-            PacketType::Control(Control::KeyExchangeReply(ke_reply)) => {
-                self.handle_key_exchange_reply(ke_reply, msg)
-            }
-            PacketType::Control(Control::SessionTerminated(st)) => {
-                self.handle_session_terminated(st)
-            }
-        }
-    }
-
-    fn handle_key_exchange_init(
-        &self,
-        ke_init: &KeyExchangeInit<'_>,
-        msg: &Message<'_>,
-    ) -> Result<Option<Vec<ReplyType>>> {
-        // OBUs forward KeyExchangeInit up the tree toward the server.
-        let routing = self
-            .routing
-            .read()
-            .expect("routing table read lock poisoned");
-        let Some(upstream) = routing.get_route_to(None) else {
-            tracing::warn!(
-                obu = %ke_init.sender(),
-                "No upstream route — dropping KeyExchangeInit (relay OBU has no path to server)"
-            );
-            return Ok(None);
-        };
-
-        // Record the downstream path so we can route the reply back without
-        // relying solely on the heartbeat-reply-based routing table, which may
-        // not yet have an entry for the initiating OBU when the exchange starts.
-        if let Ok(from_mac) = msg.from() {
-            self.downstream_client_cache
-                .store_mac(ke_init.sender(), from_mac);
-        }
-
-        // Preserve all fields (algorithm, key material, signature) when forwarding.
-        let init = ke_init.clone_into_owned();
-        let fwd = Message::new(
-            self.device.mac_address(),
-            upstream.mac,
-            PacketType::Control(Control::KeyExchangeInit(init)),
-        );
-        let wire: Vec<u8> = (&fwd).into();
-        tracing::info!(
-            obu = %ke_init.sender(),
-            via = %upstream.mac,
-            signed = ke_init.is_signed(),
-            "Forwarding KeyExchangeInit upstream"
-        );
-        Ok(Some(vec![ReplyType::WireFlat(wire)]))
-    }
-
-    fn handle_session_terminated(
-        &self,
-        st: &SessionTerminated<'_>,
-    ) -> Result<Option<Vec<ReplyType>>> {
-        let target = st.target();
-        let our_mac = self.device.mac_address();
-
-        if target != our_mac {
-            // Not for us — forward toward the target OBU.
-            let routing = self
-                .routing
-                .read()
-                .expect("routing table read lock poisoned");
-            let Some(next_hop) = routing.get_route_to(Some(target)) else {
-                tracing::debug!(
-                    target = %target,
-                    "No route to forward SessionTerminated, dropping"
-                );
-                return Ok(None);
-            };
-            let owned = st.clone_into_owned();
-            let fwd = Message::new(
-                our_mac,
-                next_hop.mac,
-                PacketType::Control(Control::SessionTerminated(owned)),
-            );
-            let wire: Vec<u8> = (&fwd).into();
-            tracing::debug!(
-                target = %target,
-                via = %next_hop.mac,
-                "Forwarding SessionTerminated down the tree"
-            );
-            return Ok(Some(vec![ReplyType::WireFlat(wire)]));
-        }
-
-        // It's for us.
-        //
-        // Authenticate the revocation notice before acting on it to prevent DoS:
-        //   1. If server_signing_pubkey is configured: require a valid signature.
-        //      Unsigned messages are dropped.
-        //   2. Verify the signature over [0x04][TARGET_MAC 6B][TIMESTAMP 8B][NONCE 8B].
-        //   3. Check timestamp is within the validity window.
-        //   4. Check the nonce has not been seen within the window (replay prevention).
-        //      The cache is time-bounded: entries older than VALIDITY_SECS are pruned
-        //      on each check, so it never accumulates stale nonces that could be replayed
-        //      after a count-bounded window wraps.
-        use node_lib::messages::control::session_terminated::{
-            CLOCK_SKEW_TOLERANCE_SECS, VALIDITY_SECS,
-        };
-        if let Some(ref expected_hex) = self.args.obu_params.server_signing_pubkey {
-            let (ts, nonce, algo_id, sig) = match (
-                st.timestamp_secs(),
-                st.nonce(),
-                st.sig_algo_id(),
-                st.signature(),
-            ) {
-                (Some(t), Some(n), Some(algo), Some(s)) => (t, n, algo, s),
-                _ => {
-                    tracing::warn!(
-                        "SessionTerminated is unsigned but server_signing_pubkey is \
-                             configured — dropping (possible replay or misconfigured server)"
-                    );
-                    return Ok(None);
-                }
-            };
-
-            // Timestamp check: reject messages outside the validity window.
-            let now_secs = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let too_old = ts < now_secs.saturating_sub(VALIDITY_SECS);
-            let too_new = ts > now_secs.saturating_add(CLOCK_SKEW_TOLERANCE_SECS);
-            if too_old || too_new {
-                tracing::warn!(
-                    msg_ts = ts,
-                    now = now_secs,
-                    "SessionTerminated timestamp outside validity window — dropping"
-                );
-                return Ok(None);
-            }
-
-            let expected_bytes = match decode_hex(expected_hex) {
-                Some(b) if b.len() == 32 || b.len() == 1952 => b,
-                _ => {
-                    tracing::warn!(
-                        "server_signing_pubkey is invalid hex or has wrong length, \
-                         cannot verify SessionTerminated — dropping"
-                    );
-                    return Ok(None);
-                }
-            };
-
-            let algo = match node_lib::crypto::sig_algo_from_id(algo_id) {
-                Some(a) => a,
-                None => {
-                    tracing::warn!(
-                        algo_id,
-                        "SessionTerminated uses unknown signature algorithm — dropping"
-                    );
-                    return Ok(None);
-                }
-            };
-
-            let mut payload = vec![0x04u8];
-            payload.extend_from_slice(&our_mac.bytes());
-            payload.extend_from_slice(&ts.to_be_bytes());
-            payload.extend_from_slice(nonce);
-
-            if let Err(e) =
-                node_lib::crypto::verify_dh_signature(algo, &payload, &expected_bytes, sig)
-            {
-                tracing::warn!(error = %e, "SessionTerminated has invalid signature — dropping");
-                return Ok(None);
-            }
-
-            // Signature valid — check nonce freshness using a time-bounded cache.
-            let validity = std::time::Duration::from_secs(VALIDITY_SECS);
-            {
-                let mut cache = self
-                    .seen_revocation_nonces
-                    .lock()
-                    .expect("revocation nonce cache lock poisoned");
-                // Prune expired entries first.
-                while cache.front().is_some_and(|(_, t)| t.elapsed() > validity) {
-                    cache.pop_front();
-                }
-                if cache.iter().any(|(n, _)| n == nonce) {
-                    tracing::debug!("SessionTerminated nonce already seen — dropping (replay)");
-                    return Ok(None);
-                }
-                cache.push_back((*nonce, std::time::Instant::now()));
-            }
-
-            tracing::debug!(
-                ts,
-                "SessionTerminated signature, timestamp, and nonce verified"
-            );
-        }
-
-        // Clear the DH session and wake the re-keying task.
-        {
-            let mut store = self
-                .dh_key_store
-                .write()
-                .expect("dh key store write lock poisoned");
-            store.clear_session(server_virtual_mac());
-        }
-        tracing::warn!(
-            "SessionTerminated received from server — DH session cleared, re-keying immediately"
-        );
-        self.rekey_notify.notify_one();
-        Ok(None)
-    }
-
-    fn handle_key_exchange_reply(
-        &self,
-        ke_reply: &KeyExchangeReply<'_>,
-        msg: &Message<'_>,
-    ) -> Result<Option<Vec<ReplyType>>> {
-        // Log receipt unconditionally so we can confirm delivery regardless of
-        // whether encryption is enabled, the key_id matches, or the reply is
-        // for this node vs a downstream relay target.
-        tracing::info!(
-            key_id = ke_reply.key_id(),
-            dest = %ke_reply.sender(),
-            my_mac = %self.device.mac_address(),
-            wire_from = ?msg.from().ok(),
-            "KeyExchangeReply received on VANET"
-        );
-
-        if !self.args.obu_params.enable_encryption {
-            return Ok(None);
-        }
-
-        // The sender field carries the final destination OBU MAC (set by the server).
-        // Use it — rather than msg.to() — to decide whether to consume or relay:
-        // msg.to() is always the VANET next-hop (this node) due to per-hop unicast
-        // delivery enforced by the channel MAC filter, so it cannot distinguish
-        // "the reply is for me" from "the reply arrived here via me as a relay hop".
-        let dest = ke_reply.sender();
-        if dest != self.device.mac_address() {
-            // Not for us — forward down the tree toward the target OBU.
-            //
-            // Prefer the downstream_client_cache over the routing table: it is
-            // populated when we forward a KeyExchangeInit upstream, so it is
-            // available immediately even before heartbeat-reply-based routing
-            // entries exist for the downstream OBU.
-            let cache_hit = self.downstream_client_cache.get(dest);
-            let next_hop_mac = cache_hit.or_else(|| {
-                let routing = self
-                    .routing
-                    .read()
-                    .expect("routing table read lock poisoned");
-                routing.get_route_to(Some(dest)).map(|r| r.mac)
-            });
-            let Some(next_hop_mac) = next_hop_mac else {
-                tracing::warn!(
-                    dest = %dest,
-                    key_id = ke_reply.key_id(),
-                    "No route to forward KeyExchangeReply (not in downstream cache or routing table), dropping"
-                );
-                return Ok(None);
-            };
-
-            // Preserve all fields (algorithm, key material, signature) when forwarding.
-            let reply = ke_reply.clone_into_owned();
-            let fwd = Message::new(
-                self.device.mac_address(),
-                next_hop_mac,
-                PacketType::Control(Control::KeyExchangeReply(reply)),
-            );
-            let wire: Vec<u8> = (&fwd).into();
-            tracing::info!(
-                dest = %dest,
-                via = %next_hop_mac,
-                key_id = ke_reply.key_id(),
-                "Relaying KeyExchangeReply down the tree"
-            );
-            return Ok(Some(vec![ReplyType::WireFlat(wire)]));
-        }
-
-        // It's for us — verify the server's signature before completing the exchange.
-        if self.args.obu_params.enable_dh_signatures {
-            match (
-                ke_reply.sig_algo_id(),
-                ke_reply.signing_pubkey(),
-                ke_reply.signature(),
-            ) {
-                (Some(sig_algo), Some(spk), Some(sig)) => {
-                    let algo = match sig_algo_from_id(sig_algo) {
-                        Some(a) => a,
-                        None => {
-                            tracing::warn!(
-                                sig_algo_id = sig_algo,
-                                key_id = ke_reply.key_id(),
-                                "KeyExchangeReply uses unknown signature algorithm, dropping"
-                            );
-                            return Ok(None);
-                        }
-                    };
-                    let base = ke_reply.base_payload();
-                    if let Err(e) = node_lib::crypto::verify_dh_signature(algo, &base, spk, sig) {
-                        tracing::warn!(
-                            error = %e,
-                            key_id = ke_reply.key_id(),
-                            "KeyExchangeReply has invalid signature, dropping"
-                        );
-                        return Ok(None);
-                    }
-                    tracing::debug!(
-                        key_id = ke_reply.key_id(),
-                        "KeyExchangeReply signature verified"
-                    );
-                }
-                _ => {
-                    tracing::warn!(
-                        key_id = ke_reply.key_id(),
-                        "KeyExchangeReply is unsigned but enable_dh_signatures is set, dropping"
-                    );
-                    return Ok(None);
-                }
+            PacketType::Auth(Auth::KeyExchangeInit(ke_init)) => self
+                .crypto
+                .handle_key_exchange_init(ke_init, msg, self.device.mac_address(), &self.routing),
+            PacketType::Auth(Auth::KeyExchangeReply(ke_reply)) => self
+                .crypto
+                .handle_key_exchange_reply(ke_reply, msg, self.device.mac_address(), &self.routing),
+            PacketType::Auth(Auth::SessionTerminated(st)) => {
+                self.crypto
+                    .handle_session_terminated(st, self.device.mac_address(), &self.routing)
             }
         }
-
-        // PKI: if a pinned server public key is configured, reject replies
-        // from any server whose signing key doesn't match.
-        // Signature verification must be enabled; without it the key bytes are
-        // unverified and an attacker could include the pinned key in a forged reply.
-        if self.args.obu_params.server_signing_pubkey.is_some()
-            && !self.args.obu_params.enable_dh_signatures
-        {
-            tracing::warn!(
-                key_id = ke_reply.key_id(),
-                "server_signing_pubkey is configured but enable_dh_signatures is false; \
-                 dropping KeyExchangeReply to prevent key-pinning bypass"
-            );
-            return Ok(None);
-        }
-        if let Some(ref expected_hex) = self.args.obu_params.server_signing_pubkey {
-            let expected_bytes =
-                decode_hex(expected_hex).filter(|b| b.len() == 32 || b.len() == 1952);
-            if expected_bytes.is_none() && !expected_hex.is_empty() {
-                tracing::warn!(
-                    key_id = ke_reply.key_id(),
-                    "server_signing_pubkey is invalid hex or has wrong length \
-                     (expected 32B Ed25519 or 1952B ML-DSA-65), dropping reply"
-                );
-                return Ok(None);
-            }
-            match (ke_reply.signing_pubkey(), expected_bytes) {
-                (Some(spk), Some(ref expected)) if spk == expected.as_slice() => {
-                    tracing::debug!(
-                        key_id = ke_reply.key_id(),
-                        "KeyExchangeReply signing key matches pinned server pubkey"
-                    );
-                }
-                (Some(_), Some(_)) => {
-                    tracing::warn!(
-                        key_id = ke_reply.key_id(),
-                        "KeyExchangeReply signing key does not match pinned server pubkey, dropping"
-                    );
-                    return Ok(None);
-                }
-                (None, _) => {
-                    tracing::warn!(
-                        key_id = ke_reply.key_id(),
-                        "KeyExchangeReply is unsigned but server_signing_pubkey is configured, dropping"
-                    );
-                    return Ok(None);
-                }
-                (_, None) => {
-                    tracing::warn!(
-                        "server_signing_pubkey is not valid hex, cannot verify reply — dropping"
-                    );
-                    return Ok(None);
-                }
-            }
-        }
-
-        // Validate that the reply algorithm matches what we initiated.
-        // Rejecting mismatches prevents an attacker from downgrading the algorithm
-        // by rewriting the algo_id byte in a relayed reply.
-        {
-            use node_lib::messages::control::key_exchange::{KE_ALGO_ML_KEM_768, KE_ALGO_X25519};
-            let expected_algo_id = match self.crypto_config.dh_group {
-                node_lib::crypto::DhGroup::X25519 => KE_ALGO_X25519,
-                node_lib::crypto::DhGroup::MlKem768 => KE_ALGO_ML_KEM_768,
-            };
-            if ke_reply.algo_id() != expected_algo_id {
-                tracing::warn!(
-                    key_id = ke_reply.key_id(),
-                    expected = expected_algo_id,
-                    received = ke_reply.algo_id(),
-                    "KeyExchangeReply algo_id does not match initiated algorithm, dropping"
-                );
-                return Ok(None);
-            }
-        }
-
-        // Complete the key exchange.
-        let key_id = ke_reply.key_id();
-        let peer_response = ke_reply.key_material();
-
-        let result = {
-            let mut store = self
-                .dh_key_store
-                .write()
-                .expect("dh key store write lock poisoned");
-            store.complete_exchange(server_virtual_mac(), key_id, peer_response)
-        };
-
-        match result {
-            Some((ref derived_key, elapsed)) => {
-                tracing::info!(
-                    key_id = key_id,
-                    cipher = %self.crypto_config.cipher,
-                    kdf = %self.crypto_config.kdf,
-                    key_len = derived_key.len(),
-                    elapsed_ms = elapsed.as_millis() as u64,
-                    "DH key exchange with server completed, session key established"
-                );
-            }
-            None => {
-                tracing::warn!(
-                    key_id = key_id,
-                    "Failed to complete DH key exchange with server — no matching pending exchange"
-                );
-            }
-        }
-
-        Ok(None)
     }
 }
 
@@ -1191,7 +328,7 @@ pub(crate) fn handle_msg_for_test(
     device_mac: mac_address::MacAddress,
     msg: &node_lib::messages::message::Message<'_>,
 ) -> anyhow::Result<Option<Vec<ReplyType>>> {
-    use node_lib::messages::{control::Control, data::Data, packet_type::PacketType};
+    use node_lib::messages::{auth::Auth, control::Control, data::Data, packet_type::PacketType};
 
     match msg.get_packet_type() {
         PacketType::Data(Data::Upstream(buf)) => {
@@ -1247,9 +384,9 @@ pub(crate) fn handle_msg_for_test(
             .write()
             .expect("routing table write lock poisoned in test helper")
             .handle_heartbeat_reply(msg, device_mac),
-        PacketType::Control(Control::KeyExchangeInit(_))
-        | PacketType::Control(Control::KeyExchangeReply(_))
-        | PacketType::Control(Control::SessionTerminated(_)) => {
+        PacketType::Auth(Auth::KeyExchangeInit(_))
+        | PacketType::Auth(Auth::KeyExchangeReply(_))
+        | PacketType::Auth(Auth::SessionTerminated(_)) => {
             // Key exchange and session messages not handled in basic test helper
             Ok(None)
         }

--- a/obu_lib/src/control/session.rs
+++ b/obu_lib/src/control/session.rs
@@ -1,8 +1,72 @@
-use super::node::ReplyType;
-use anyhow::Result;
+use super::dh_key_store::DhKeyStore;
+use super::node::{self, ReplyType};
+use super::routing::Routing;
+use anyhow::{anyhow, Result};
+use common::network_interface::NetworkInterface;
 use common::tun::Tun;
 use futures::Future;
-use std::sync::Arc;
+use mac_address::MacAddress;
+use node_lib::control::client_cache::ClientCache;
+use node_lib::crypto::{CryptoConfig, SigningKeypair};
+use node_lib::messages::{
+    auth::{
+        key_exchange::{KeyExchangeInit, KeyExchangeReply},
+        session_terminated::{SessionTerminated, CLOCK_SKEW_TOLERANCE_SECS, VALIDITY_SECS},
+        Auth,
+    },
+    data::ToUpstream,
+    message::Message,
+    packet_type::PacketType,
+};
+use node_lib::{Shared, SharedDevice, SharedTun};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, RwLock};
+use tokio::sync::Notify;
+use tokio::time::Duration;
+use tracing::Instrument;
+
+use crate::args::ObuArgs;
+
+// ── Type aliases ────────────────────────────────────────────────────────────
+
+pub(super) type SharedKeyStore = Arc<RwLock<DhKeyStore>>;
+type RevocationNonceCache = Arc<Mutex<VecDeque<([u8; 8], std::time::Instant)>>>;
+
+// ── DH exchange action ───────────────────────────────────────────────────────
+
+/// Action to take when a DH key exchange is needed.
+#[derive(Debug, Clone, Copy)]
+enum DhAction {
+    /// No pending exchange exists — start a fresh one.
+    Initiate,
+    /// A pending exchange timed out — re-use its retry counter.
+    Reinitiate,
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Decode a hex string of any length into bytes. Returns `None` on invalid hex.
+fn decode_hex(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..s.len() / 2)
+        .map(|i| u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok())
+        .collect()
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Virtual MAC used to key the DH store for the server tunnel.
+/// The OBU negotiates keys with the server (not peers), so we use a
+/// fixed sentinel MAC as the store key.
+pub(super) fn server_virtual_mac() -> MacAddress {
+    MacAddress::new([0, 0, 0, 0, 0, 0])
+}
+
+// ── Session (TUN read) ────────────────────────────────────────────────────────
 
 // Session support is under development - types are placeholders for future implementation
 #[allow(dead_code)]
@@ -43,5 +107,849 @@ impl Session {
                 todo!()
             }
         }
+    }
+}
+
+// ── CryptoState ───────────────────────────────────────────────────────────────
+
+/// All DH key-exchange and session-crypto state for an OBU.
+///
+/// Owns the key store, session flags, signing keypair, nonce replay-prevention
+/// cache, and downstream client cache used for relay-mode key-exchange
+/// forwarding.  Lock-order rule: always acquire `dh_key_store` before
+/// `seen_revocation_nonces`; never hold either across an `.await`.
+pub(super) struct CryptoState {
+    pub(super) dh_key_store: SharedKeyStore,
+    crypto_config: CryptoConfig,
+    signing_keypair: Option<Arc<SigningKeypair>>,
+    rekey_notify: Arc<Notify>,
+    /// Time-bounded cache of recently-seen `SessionTerminated` nonces.
+    seen_revocation_nonces: RevocationNonceCache,
+    /// Downstream client cache for relay-mode operation.
+    pub(super) downstream_client_cache: Arc<ClientCache>,
+    // ── config values extracted from ObuArgs at construction ────────────────
+    pub(super) enable_encryption: bool,
+    enable_dh_signatures: bool,
+    server_signing_pubkey: Option<String>,
+    dh_rekey_interval_ms: u64,
+    dh_key_lifetime_ms: u64,
+    dh_reply_timeout_ms: u64,
+}
+
+impl CryptoState {
+    /// Build crypto state from OBU args.  Generates or derives the signing
+    /// keypair when `enable_dh_signatures` is set, and logs the public key.
+    pub(super) fn new(args: &ObuArgs) -> Result<Self> {
+        let crypto_config = CryptoConfig {
+            cipher: args.obu_params.cipher,
+            kdf: args.obu_params.kdf,
+            dh_group: args.obu_params.dh_group,
+            signing_algorithm: args.obu_params.signing_algorithm,
+        };
+
+        let signing_algo = args.obu_params.signing_algorithm;
+        let signing_keypair = if args.obu_params.enable_dh_signatures {
+            let kp = if let Some(ref hex_seed) = args.obu_params.signing_key_seed {
+                let seed = node_lib::crypto::decode_hex_32(hex_seed).ok_or_else(|| {
+                    anyhow!("signing_key_seed must be exactly 64 hex characters (32 bytes)")
+                })?;
+                SigningKeypair::from_seed(signing_algo, seed)
+            } else {
+                SigningKeypair::generate(signing_algo)
+            };
+            let pubkey_hex = encode_hex(&kp.verifying_key_bytes());
+            tracing::info!(
+                signing_pubkey = %pubkey_hex,
+                "DH signing enabled — register this public key in the server's \
+                 dh_signing_allowlist to enforce PKI authentication"
+            );
+            Some(Arc::new(kp))
+        } else {
+            None
+        };
+
+        tracing::info!(
+            cipher = %crypto_config.cipher,
+            kdf = %crypto_config.kdf,
+            dh_group = %crypto_config.dh_group,
+            encryption = args.obu_params.enable_encryption,
+            dh_rekey_interval_ms = args.obu_params.dh_rekey_interval_ms,
+            dh_key_lifetime_ms = args.obu_params.dh_key_lifetime_ms,
+            dh_reply_timeout_ms = args.obu_params.dh_reply_timeout_ms,
+            "CryptoState initialized"
+        );
+
+        Ok(Self {
+            dh_key_store: Arc::new(RwLock::new(DhKeyStore::new(crypto_config))),
+            crypto_config,
+            signing_keypair,
+            rekey_notify: Arc::new(Notify::new()),
+            seen_revocation_nonces: Arc::new(Mutex::new(VecDeque::new())),
+            downstream_client_cache: Arc::new(ClientCache::new()),
+            enable_encryption: args.obu_params.enable_encryption,
+            enable_dh_signatures: args.obu_params.enable_dh_signatures,
+            server_signing_pubkey: args.obu_params.server_signing_pubkey.clone(),
+            dh_rekey_interval_ms: args.obu_params.dh_rekey_interval_ms,
+            dh_key_lifetime_ms: args.obu_params.dh_key_lifetime_ms,
+            dh_reply_timeout_ms: args.obu_params.dh_reply_timeout_ms,
+        })
+    }
+
+    // ── Key-store accessors ──────────────────────────────────────────────────
+
+    /// Check whether a DH session with the server has been established.
+    pub(super) fn has_dh_session(&self) -> bool {
+        self.dh_key_store
+            .read()
+            .expect("dh key store read lock poisoned")
+            .has_established_key(server_virtual_mac())
+    }
+
+    /// Return the established DH session info: `(key_id, age_secs)`.
+    /// Returns `None` when no session has been established yet.
+    pub(super) fn get_dh_session_info(&self) -> Option<(u32, u64)> {
+        self.dh_key_store
+            .read()
+            .expect("dh key store read lock poisoned")
+            .get_session_info(server_virtual_mac())
+    }
+
+    /// Immediately trigger a DH re-key exchange, bypassing the normal interval.
+    ///
+    /// Clears the current established session (if any) and wakes the re-keying
+    /// task so it initiates a new key exchange on the next loop iteration.
+    pub(super) fn trigger_rekey(&self) {
+        {
+            let mut store = self
+                .dh_key_store
+                .write()
+                .expect("dh key store write lock poisoned");
+            store.clear_session(server_virtual_mac());
+        }
+        self.rekey_notify.notify_one();
+        tracing::info!("DH re-key triggered manually via admin interface");
+    }
+
+    /// Return whether a pending DH exchange is in progress.
+    pub(super) fn has_dh_pending(&self) -> bool {
+        self.dh_key_store
+            .read()
+            .expect("dh key store read lock poisoned")
+            .has_pending(server_virtual_mac())
+    }
+
+    // ── Data-path helpers ────────────────────────────────────────────────────
+
+    /// Decrypt an inbound downstream payload.
+    ///
+    /// Returns `Some(plaintext)` on success (or when encryption is disabled),
+    /// and `None` when the frame must be dropped (no session, or decrypt error).
+    pub(super) fn decrypt_downstream(&self, data: &[u8]) -> Option<Vec<u8>> {
+        if !self.enable_encryption {
+            return Some(data.to_vec());
+        }
+        let dh_store = self
+            .dh_key_store
+            .read()
+            .expect("dh key store read lock poisoned");
+        let dh_key = dh_store.get_key(server_virtual_mac());
+        let cipher = self.crypto_config.cipher;
+        let Some(key) = dh_key else {
+            tracing::debug!(
+                size = data.len(),
+                cipher = %cipher,
+                "No DH session established with server, dropping downstream frame"
+            );
+            return None;
+        };
+        match node_lib::crypto::decrypt_with_config(cipher, data, key) {
+            Ok(decrypted) => Some(decrypted),
+            Err(e) => {
+                tracing::warn!(
+                    size = data.len(),
+                    cipher = %cipher,
+                    error = %e,
+                    "Failed to decrypt downstream frame, dropping"
+                );
+                None
+            }
+        }
+    }
+
+    // ── Background tasks ─────────────────────────────────────────────────────
+
+    /// Spawn the periodic DH re-keying task.
+    ///
+    /// Normally wakes every `dh_rekey_interval_ms` to check whether a new key
+    /// exchange is needed.  The `rekey_notify` Notify bypasses the sleep so the
+    /// task reacts immediately when a `SessionTerminated` notice clears the key.
+    pub(super) fn start_dh_rekey_task(
+        crypto: Arc<Self>,
+        device: SharedDevice,
+        routing: Shared<Routing>,
+        node_name: String,
+    ) -> Result<()> {
+        tracing::info!(
+            cipher = %crypto.crypto_config.cipher,
+            kdf = %crypto.crypto_config.kdf,
+            dh_group = %crypto.crypto_config.dh_group,
+            rekey_interval_ms = crypto.dh_rekey_interval_ms,
+            "Starting DH re-keying task"
+        );
+        let rekey_interval = Duration::from_millis(crypto.dh_rekey_interval_ms);
+        let key_lifetime_ms = crypto.dh_key_lifetime_ms;
+        let reply_timeout_ms = crypto.dh_reply_timeout_ms;
+        let rekey_notify = crypto.rekey_notify.clone();
+
+        let span = tracing::info_span!("node", name = %node_name);
+        tokio::task::spawn(
+            async move {
+                // Initial delay to allow routing to establish
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                let cached_upstream = || {
+                    routing
+                        .read()
+                        .expect("routing read lock poisoned")
+                        .get_cached_upstream()
+                };
+                tracing::info!(
+                    upstream = ?cached_upstream(),
+                    "DH rekey task starting (initial delay elapsed)"
+                );
+
+                loop {
+                    if let Some(mut upstream_mac) = cached_upstream() {
+                        // Use server_virtual_mac() for key store lookups — the key
+                        // is with the server, not with a specific RSU/peer.
+                        let needs_exchange = {
+                            let store = crypto
+                                .dh_key_store
+                                .read()
+                                .expect("dh key store read lock poisoned");
+                            let no_key = !store.has_established_key(server_virtual_mac());
+                            let expired =
+                                store.is_key_expired(server_virtual_mac(), key_lifetime_ms);
+                            if expired {
+                                tracing::debug!(
+                                    via = %upstream_mac,
+                                    lifetime_ms = key_lifetime_ms,
+                                    "Server DH key expired, initiating re-key"
+                                );
+                            }
+                            no_key || expired
+                        };
+
+                        if needs_exchange {
+                            // Determine what action to take:
+                            // - If no pending exchange, initiate a new one.
+                            // - If pending exchange timed out, re-initiate (preserving retry count).
+                            //   After 3 consecutive timeouts, failover to the next-best RSU candidate.
+                            // - If pending exchange still in progress, wait.
+                            let action: Option<DhAction> = {
+                                let store = crypto
+                                    .dh_key_store
+                                    .read()
+                                    .expect("dh key store read lock poisoned");
+                                if !store.has_pending(server_virtual_mac()) {
+                                    Some(DhAction::Initiate)
+                                } else if store
+                                    .is_pending_timed_out(server_virtual_mac(), reply_timeout_ms)
+                                {
+                                    let retries =
+                                        store.pending_retries(server_virtual_mac()).unwrap_or(0);
+                                    if retries >= 3 {
+                                        if let Some(new_upstream) = routing
+                                            .read()
+                                            .expect("routing read lock")
+                                            .failover_cached_upstream()
+                                        {
+                                            tracing::warn!(
+                                                old_via = %upstream_mac,
+                                                new_via = %new_upstream,
+                                                retry = retries + 1,
+                                                "DH timeout threshold reached, failing over to next RSU candidate"
+                                            );
+                                            upstream_mac = new_upstream;
+                                        }
+                                    } else {
+                                        tracing::warn!(
+                                            via = %upstream_mac,
+                                            retry = retries + 1,
+                                            "Server DH reply timed out, re-initiating (no session — packets will be dropped until established)"
+                                        );
+                                    }
+                                    Some(DhAction::Reinitiate)
+                                } else {
+                                    None // still pending, wait
+                                }
+                            };
+
+                            if let Some(action) = action {
+                                let (key_id, pub_key) = {
+                                    let mut store = crypto
+                                        .dh_key_store
+                                        .write()
+                                        .expect("dh key store write lock poisoned");
+                                    match action {
+                                        DhAction::Reinitiate => {
+                                            store.reinitiate_exchange(server_virtual_mac())
+                                        }
+                                        DhAction::Initiate => {
+                                            store.initiate_exchange(server_virtual_mac())
+                                        }
+                                    }
+                                };
+
+                                let our_mac = device.mac_address();
+                                let dh_group = crypto.crypto_config.dh_group;
+                                let init_msg = if let Some(ref kp) = crypto.signing_keypair {
+                                    let unsigned = KeyExchangeInit::new_unsigned(
+                                        dh_group,
+                                        key_id,
+                                        pub_key.clone(),
+                                        our_mac,
+                                    );
+                                    let base = unsigned.base_payload();
+                                    let sig = kp.sign(&base);
+                                    let spk = kp.verifying_key_bytes();
+                                    KeyExchangeInit::new_signed(
+                                        dh_group,
+                                        key_id,
+                                        pub_key,
+                                        our_mac,
+                                        kp.signing_algorithm(),
+                                        spk,
+                                        sig,
+                                    )
+                                } else {
+                                    KeyExchangeInit::new_unsigned(dh_group, key_id, pub_key, our_mac)
+                                };
+                                let msg = Message::new(
+                                    our_mac,
+                                    upstream_mac,
+                                    PacketType::Auth(Auth::KeyExchangeInit(init_msg)),
+                                );
+                                let wire: Vec<u8> = (&msg).into();
+
+                                if let Err(e) = device.send(&wire).await {
+                                    tracing::warn!(
+                                        error = %e,
+                                        via = %upstream_mac,
+                                        key_id = key_id,
+                                        "Failed to send DH KeyExchangeInit (for server)"
+                                    );
+                                } else {
+                                    tracing::info!(
+                                        via = %upstream_mac,
+                                        key_id = key_id,
+                                        mode = ?action,
+                                        dh_group = %crypto.crypto_config.dh_group,
+                                        "Sent DH KeyExchangeInit upstream"
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            "DH rekey task: no upstream RSU cached yet — skipping exchange until next wakeup"
+                        );
+                    }
+
+                    // Wait for either the normal rekey interval or an early wake-up
+                    // triggered by receiving a SessionTerminated notice.
+                    // When a DH exchange is in-flight, use a short sleep equal to
+                    // reply_timeout_ms so we wake promptly to detect the timeout and
+                    // retransmit.  When no upstream was available, also use a short
+                    // retry so we attempt again as soon as the first heartbeat
+                    // populates the routing table.
+                    let no_upstream = cached_upstream().is_none();
+                    let exchange_pending = crypto
+                        .dh_key_store
+                        .read()
+                        .map(|g| g.has_pending(server_virtual_mac()))
+                        .unwrap_or(false);
+                    let sleep_duration = if exchange_pending || no_upstream {
+                        Duration::from_millis(reply_timeout_ms)
+                    } else {
+                        rekey_interval
+                    };
+                    tokio::select! {
+                        _ = tokio::time::sleep(sleep_duration) => {}
+                        _ = rekey_notify.notified() => {
+                            tracing::debug!("DH rekey task woken early by SessionTerminated");
+                        }
+                    }
+                }
+            }
+            .instrument(span),
+        );
+        Ok(())
+    }
+
+    /// Spawn the TUN session task.
+    ///
+    /// Reads IP frames from the TUN interface, optionally encrypts them with
+    /// the established DH session key, and forwards them upstream.
+    pub(super) fn start_session_task(
+        crypto: Arc<Self>,
+        session: Arc<Session>,
+        tun: SharedTun,
+        device: SharedDevice,
+        routing: Shared<Routing>,
+        node_name: String,
+    ) -> Result<()> {
+        let span = tracing::info_span!("node", name = %node_name);
+        tokio::task::spawn(
+            async move {
+                loop {
+                    let devicec = device.clone();
+                    let routing_for_closure = routing.clone();
+                    let routing_for_handle = routing.clone();
+                    let crypto_c = crypto.clone();
+                    let messages = session
+                        .process(|x, size| async move {
+                            let y: &[u8] = &x[..size];
+                            let Some(upstream) = routing_for_closure
+                                .read()
+                                .expect("routing table read lock poisoned in session task")
+                                .get_route_to(None)
+                            else {
+                                return Ok(None);
+                            };
+
+                            let payload_data = if crypto_c.enable_encryption {
+                                // Always use server_virtual_mac() — the key is
+                                // negotiated with the server, not the RSU.
+                                let dh_store_guard = crypto_c
+                                    .dh_key_store
+                                    .read()
+                                    .expect("dh key store read lock poisoned");
+                                let dh_key = dh_store_guard.get_key(server_virtual_mac());
+                                let cipher = crypto_c.crypto_config.cipher;
+                                let Some(key) = dh_key else {
+                                    tracing::debug!(
+                                        size = y.len(),
+                                        cipher = %cipher,
+                                        "No DH session established with server, dropping upstream frame"
+                                    );
+                                    return Ok(None);
+                                };
+                                match node_lib::crypto::encrypt_with_config(cipher, y, key) {
+                                    Ok(encrypted_data) => encrypted_data,
+                                    Err(e) => {
+                                        tracing::error!(
+                                            size = y.len(),
+                                            cipher = %cipher,
+                                            error = %e,
+                                            "Failed to encrypt upstream frame"
+                                        );
+                                        return Ok(None);
+                                    }
+                                }
+                            } else {
+                                y.to_vec()
+                            };
+
+                            let origin = devicec.mac_address();
+                            let mut wire = Vec::with_capacity(24 + payload_data.len());
+                            let tu = ToUpstream::new(origin, &payload_data);
+                            Message::serialize_upstream_forward_into(
+                                &tu,
+                                origin,
+                                upstream.mac,
+                                &mut wire,
+                            );
+                            let outgoing = vec![ReplyType::WireFlat(wire)];
+                            Ok(Some(outgoing))
+                        })
+                        .await;
+
+                    if let Ok(Some(messages)) = messages {
+                        let _ = node::handle_messages(
+                            messages,
+                            &tun,
+                            &device,
+                            Some(routing_for_handle.clone()),
+                        )
+                        .await;
+                    }
+                }
+            }
+            .instrument(span),
+        );
+        Ok(())
+    }
+
+    // ── Control message handlers ──────────────────────────────────────────────
+
+    /// Handle an inbound `KeyExchangeInit`.
+    ///
+    /// OBUs forward the message upstream toward the server, recording the
+    /// downstream path in the client cache so the reply can be routed back.
+    pub(super) fn handle_key_exchange_init(
+        &self,
+        ke_init: &KeyExchangeInit<'_>,
+        msg: &Message<'_>,
+        device_mac: MacAddress,
+        routing: &Shared<Routing>,
+    ) -> Result<Option<Vec<ReplyType>>> {
+        let routing = routing.read().expect("routing table read lock poisoned");
+        let Some(upstream) = routing.get_route_to(None) else {
+            tracing::warn!(
+                obu = %ke_init.sender(),
+                "No upstream route — dropping KeyExchangeInit (relay OBU has no path to server)"
+            );
+            return Ok(None);
+        };
+
+        // Record the downstream path so we can route the reply back without
+        // relying solely on the heartbeat-reply-based routing table.
+        if let Ok(from_mac) = msg.from() {
+            self.downstream_client_cache
+                .store_mac(ke_init.sender(), from_mac);
+        }
+
+        // Preserve all fields (algorithm, key material, signature) when forwarding.
+        let init = ke_init.clone_into_owned();
+        let fwd = Message::new(
+            device_mac,
+            upstream.mac,
+            PacketType::Auth(Auth::KeyExchangeInit(init)),
+        );
+        let wire: Vec<u8> = (&fwd).into();
+        tracing::info!(
+            obu = %ke_init.sender(),
+            via = %upstream.mac,
+            signed = ke_init.is_signed(),
+            "Forwarding KeyExchangeInit upstream"
+        );
+        Ok(Some(vec![ReplyType::WireFlat(wire)]))
+    }
+
+    /// Handle an inbound `SessionTerminated` notice.
+    ///
+    /// Forwards the notice downstream if it is not addressed to this node.
+    /// If it is for us, authenticates it (signature, timestamp, nonce replay
+    /// prevention), clears the DH session, and wakes the re-keying task.
+    pub(super) fn handle_session_terminated(
+        &self,
+        st: &SessionTerminated<'_>,
+        device_mac: MacAddress,
+        routing: &Shared<Routing>,
+    ) -> Result<Option<Vec<ReplyType>>> {
+        let target = st.target();
+
+        if target != device_mac {
+            // Not for us — forward toward the target OBU.
+            let routing = routing.read().expect("routing table read lock poisoned");
+            let Some(next_hop) = routing.get_route_to(Some(target)) else {
+                tracing::debug!(
+                    target = %target,
+                    "No route to forward SessionTerminated, dropping"
+                );
+                return Ok(None);
+            };
+            let owned = st.clone_into_owned();
+            let fwd = Message::new(
+                device_mac,
+                next_hop.mac,
+                PacketType::Auth(Auth::SessionTerminated(owned)),
+            );
+            let wire: Vec<u8> = (&fwd).into();
+            tracing::debug!(
+                target = %target,
+                via = %next_hop.mac,
+                "Forwarding SessionTerminated down the tree"
+            );
+            return Ok(Some(vec![ReplyType::WireFlat(wire)]));
+        }
+
+        // It's for us.
+        //
+        // Authenticate the revocation notice before acting on it to prevent DoS:
+        //   1. If server_signing_pubkey is configured: require a valid signature.
+        //   2. Verify the signature over [0x04][TARGET_MAC 6B][TIMESTAMP 8B][NONCE 8B].
+        //   3. Check timestamp is within the validity window.
+        //   4. Check the nonce has not been seen within the window (replay prevention).
+        if let Some(ref expected_hex) = self.server_signing_pubkey {
+            let (ts, nonce, algo, sig) = match (
+                st.timestamp_secs(),
+                st.nonce(),
+                st.signing_algorithm(),
+                st.signature(),
+            ) {
+                (Some(t), Some(n), Some(algo), Some(s)) => (t, n, algo, s),
+                _ => {
+                    tracing::warn!(
+                        "SessionTerminated is unsigned but server_signing_pubkey is \
+                             configured — dropping (possible replay or misconfigured server)"
+                    );
+                    return Ok(None);
+                }
+            };
+
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let too_old = ts < now_secs.saturating_sub(VALIDITY_SECS);
+            let too_new = ts > now_secs.saturating_add(CLOCK_SKEW_TOLERANCE_SECS);
+            if too_old || too_new {
+                tracing::warn!(
+                    msg_ts = ts,
+                    now = now_secs,
+                    "SessionTerminated timestamp outside validity window — dropping"
+                );
+                return Ok(None);
+            }
+
+            let expected_bytes = match decode_hex(expected_hex) {
+                Some(b) if b.len() == 32 || b.len() == 1952 => b,
+                _ => {
+                    tracing::warn!(
+                        "server_signing_pubkey is invalid hex or has wrong length, \
+                         cannot verify SessionTerminated — dropping"
+                    );
+                    return Ok(None);
+                }
+            };
+
+            let payload = SessionTerminated::build_signed_payload(device_mac, ts, *nonce);
+
+            if let Err(e) =
+                node_lib::crypto::verify_dh_signature(algo, &payload, &expected_bytes, sig)
+            {
+                tracing::warn!(error = %e, "SessionTerminated has invalid signature — dropping");
+                return Ok(None);
+            }
+
+            // Signature valid — check nonce freshness.
+            let validity = std::time::Duration::from_secs(VALIDITY_SECS);
+            {
+                let mut cache = self
+                    .seen_revocation_nonces
+                    .lock()
+                    .expect("revocation nonce cache lock poisoned");
+                while cache.front().is_some_and(|(_, t)| t.elapsed() > validity) {
+                    cache.pop_front();
+                }
+                if cache.iter().any(|(n, _)| n == nonce) {
+                    tracing::debug!("SessionTerminated nonce already seen — dropping (replay)");
+                    return Ok(None);
+                }
+                cache.push_back((*nonce, std::time::Instant::now()));
+            }
+
+            tracing::debug!(
+                ts,
+                "SessionTerminated signature, timestamp, and nonce verified"
+            );
+        }
+
+        // Clear the DH session and wake the re-keying task.
+        {
+            let mut store = self
+                .dh_key_store
+                .write()
+                .expect("dh key store write lock poisoned");
+            store.clear_session(server_virtual_mac());
+        }
+        tracing::warn!(
+            "SessionTerminated received from server — DH session cleared, re-keying immediately"
+        );
+        self.rekey_notify.notify_one();
+        Ok(None)
+    }
+
+    /// Handle an inbound `KeyExchangeReply`.
+    ///
+    /// Forwards the reply downstream when it is addressed to another OBU.
+    /// When addressed to this node, verifies the server's signature (if
+    /// configured) and completes the DH key exchange to establish a session key.
+    pub(super) fn handle_key_exchange_reply(
+        &self,
+        ke_reply: &KeyExchangeReply<'_>,
+        msg: &Message<'_>,
+        device_mac: MacAddress,
+        routing: &Shared<Routing>,
+    ) -> Result<Option<Vec<ReplyType>>> {
+        tracing::info!(
+            key_id = ke_reply.key_id(),
+            dest = %ke_reply.sender(),
+            my_mac = %device_mac,
+            wire_from = ?msg.from().ok(),
+            "KeyExchangeReply received on VANET"
+        );
+
+        if !self.enable_encryption {
+            return Ok(None);
+        }
+
+        // The sender field carries the final destination OBU MAC (set by the server).
+        let dest = ke_reply.sender();
+        if dest != device_mac {
+            // Not for us — forward down the tree.
+            let cache_hit = self.downstream_client_cache.get(dest);
+            let next_hop_mac = cache_hit.or_else(|| {
+                let routing = routing.read().expect("routing table read lock poisoned");
+                routing.get_route_to(Some(dest)).map(|r| r.mac)
+            });
+            let Some(next_hop_mac) = next_hop_mac else {
+                tracing::warn!(
+                    dest = %dest,
+                    key_id = ke_reply.key_id(),
+                    "No route to forward KeyExchangeReply (not in downstream cache or routing table), dropping"
+                );
+                return Ok(None);
+            };
+
+            let reply = ke_reply.clone_into_owned();
+            let fwd = Message::new(
+                device_mac,
+                next_hop_mac,
+                PacketType::Auth(Auth::KeyExchangeReply(reply)),
+            );
+            let wire: Vec<u8> = (&fwd).into();
+            tracing::info!(
+                dest = %dest,
+                via = %next_hop_mac,
+                key_id = ke_reply.key_id(),
+                "Relaying KeyExchangeReply down the tree"
+            );
+            return Ok(Some(vec![ReplyType::WireFlat(wire)]));
+        }
+
+        // It's for us — verify the server's signature before completing the exchange.
+        if self.enable_dh_signatures {
+            match (
+                ke_reply.signing_algorithm(),
+                ke_reply.signing_pubkey(),
+                ke_reply.signature(),
+            ) {
+                (Some(algo), Some(spk), Some(sig)) => {
+                    let base = ke_reply.base_payload();
+                    if let Err(e) = node_lib::crypto::verify_dh_signature(algo, &base, spk, sig) {
+                        tracing::warn!(
+                            error = %e,
+                            key_id = ke_reply.key_id(),
+                            "KeyExchangeReply has invalid signature, dropping"
+                        );
+                        return Ok(None);
+                    }
+                    tracing::debug!(
+                        key_id = ke_reply.key_id(),
+                        "KeyExchangeReply signature verified"
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        key_id = ke_reply.key_id(),
+                        "KeyExchangeReply is unsigned but enable_dh_signatures is set, dropping"
+                    );
+                    return Ok(None);
+                }
+            }
+        }
+
+        // PKI: if a pinned server public key is configured, reject replies from
+        // any server whose signing key doesn't match.
+        if self.server_signing_pubkey.is_some() && !self.enable_dh_signatures {
+            tracing::warn!(
+                key_id = ke_reply.key_id(),
+                "server_signing_pubkey is configured but enable_dh_signatures is false; \
+                 dropping KeyExchangeReply to prevent key-pinning bypass"
+            );
+            return Ok(None);
+        }
+        if let Some(ref expected_hex) = self.server_signing_pubkey {
+            let expected_bytes =
+                decode_hex(expected_hex).filter(|b| b.len() == 32 || b.len() == 1952);
+            if expected_bytes.is_none() && !expected_hex.is_empty() {
+                tracing::warn!(
+                    key_id = ke_reply.key_id(),
+                    "server_signing_pubkey is invalid hex or has wrong length \
+                     (expected 32B Ed25519 or 1952B ML-DSA-65), dropping reply"
+                );
+                return Ok(None);
+            }
+            match (ke_reply.signing_pubkey(), expected_bytes) {
+                (Some(spk), Some(ref expected)) if spk == expected.as_slice() => {
+                    tracing::debug!(
+                        key_id = ke_reply.key_id(),
+                        "KeyExchangeReply signing key matches pinned server pubkey"
+                    );
+                }
+                (Some(_), Some(_)) => {
+                    tracing::warn!(
+                        key_id = ke_reply.key_id(),
+                        "KeyExchangeReply signing key does not match pinned server pubkey, dropping"
+                    );
+                    return Ok(None);
+                }
+                (None, _) => {
+                    tracing::warn!(
+                        key_id = ke_reply.key_id(),
+                        "KeyExchangeReply is unsigned but server_signing_pubkey is configured, dropping"
+                    );
+                    return Ok(None);
+                }
+                (_, None) => {
+                    tracing::warn!(
+                        "server_signing_pubkey is not valid hex, cannot verify reply — dropping"
+                    );
+                    return Ok(None);
+                }
+            }
+        }
+
+        // Validate that the reply algorithm matches what we initiated.
+        {
+            let expected_group = self.crypto_config.dh_group;
+            match ke_reply.dh_group() {
+                Some(g) if g == expected_group => {}
+                received => {
+                    tracing::warn!(
+                        key_id = ke_reply.key_id(),
+                        expected = %expected_group,
+                        received = ?received,
+                        "KeyExchangeReply dh_group does not match initiated algorithm, dropping"
+                    );
+                    return Ok(None);
+                }
+            }
+        }
+
+        // Complete the key exchange.
+        let key_id = ke_reply.key_id();
+        let peer_response = ke_reply.key_material();
+
+        let result = {
+            let mut store = self
+                .dh_key_store
+                .write()
+                .expect("dh key store write lock poisoned");
+            store.complete_exchange(server_virtual_mac(), key_id, peer_response)
+        };
+
+        match result {
+            Some((ref derived_key, elapsed)) => {
+                tracing::info!(
+                    key_id = key_id,
+                    cipher = %self.crypto_config.cipher,
+                    kdf = %self.crypto_config.kdf,
+                    key_len = derived_key.len(),
+                    elapsed_ms = elapsed.as_millis() as u64,
+                    "DH key exchange with server completed, session key established"
+                );
+            }
+            None => {
+                tracing::warn!(
+                    key_id = key_id,
+                    "Failed to complete DH key exchange with server — no matching pending exchange"
+                );
+            }
+        }
+
+        Ok(None)
     }
 }

--- a/rsu_lib/src/control/mod.rs
+++ b/rsu_lib/src/control/mod.rs
@@ -13,7 +13,9 @@ use common::device::Device;
 use common::network_interface::NetworkInterface;
 use mac_address::MacAddress;
 use node::ReplyType;
-use node_lib::messages::{control::Control, data::Data, message::Message, packet_type::PacketType};
+use node_lib::messages::{
+    auth::Auth, control::Control, data::Data, message::Message, packet_type::PacketType,
+};
 use routing::Routing;
 use server_lib::cloud_protocol::{
     CloudMessage, DownstreamForward, KeyExchangeForward, KeyExchangeResponse,
@@ -264,7 +266,7 @@ impl Rsu {
                     Ok(None)
                 }
             }
-            PacketType::Control(Control::KeyExchangeInit(ke_init)) => {
+            PacketType::Auth(Auth::KeyExchangeInit(ke_init)) => {
                 // Relay KeyExchangeInit from OBU to server via cloud protocol.
                 // Use the originating OBU MAC from the payload (ke_init.sender())
                 // as the authoritative identifier, since KeyExchangeInit may be
@@ -334,11 +336,11 @@ impl Rsu {
             }
             PacketType::Data(Data::Downstream(_))
             | PacketType::Control(Control::Heartbeat(_))
-            | PacketType::Control(Control::KeyExchangeReply(_))
+            | PacketType::Auth(Auth::KeyExchangeReply(_))
             // SessionTerminated is only delivered to OBUs; the RSU forwards it via
             // handle_session_terminated_forward() when received from the server cloud
             // socket, so if it arrives on the VANET wire here it's already been handled.
-            | PacketType::Control(Control::SessionTerminated(_)) => Ok(None),
+            | PacketType::Auth(Auth::SessionTerminated(_)) => Ok(None),
         }
     }
 
@@ -563,7 +565,7 @@ impl Rsu {
         let dest_mac = rsp.obu_dest_mac;
 
         // Parse the key exchange reply payload
-        let ke_reply = match node_lib::messages::control::key_exchange::KeyExchangeReply::try_from(
+        let ke_reply = match node_lib::messages::auth::key_exchange::KeyExchangeReply::try_from(
             rsp.payload.as_slice(),
         ) {
             Ok(reply) => reply,
@@ -607,7 +609,7 @@ impl Rsu {
         let msg = Message::new(
             device.mac_address(),
             next_hop,
-            PacketType::Control(Control::KeyExchangeReply(ke_reply)),
+            PacketType::Auth(Auth::KeyExchangeReply(ke_reply)),
         );
         let wire: Vec<u8> = (&msg).into();
         let slices = [IoSlice::new(&wire)];
@@ -657,24 +659,24 @@ impl Rsu {
             return;
         };
 
-        use node_lib::messages::control::session_terminated::SessionTerminated;
+        use node_lib::messages::auth::session_terminated::SessionTerminated;
         // Pass timestamp, nonce, and signature through transparently so the OBU
         // can authenticate and replay-check the revocation notice.
         let st = match (
             stf.timestamp_secs,
             stf.nonce,
-            stf.sig_algo_id,
+            stf.sig_algo,
             stf.signature.as_deref(),
         ) {
-            (Some(ts), Some(nonce), Some(algo_id), Some(sig)) => {
-                SessionTerminated::new_signed(dest_mac, ts, nonce, algo_id, sig.to_vec())
+            (Some(ts), Some(nonce), Some(algo), Some(sig)) => {
+                SessionTerminated::new_signed(dest_mac, ts, nonce, algo, sig.to_vec())
             }
             _ => SessionTerminated::new(dest_mac),
         };
         let msg = Message::new(
             device.mac_address(),
             next_hop,
-            PacketType::Control(Control::SessionTerminated(st)),
+            PacketType::Auth(Auth::SessionTerminated(st)),
         );
         let wire: Vec<u8> = (&msg).into();
         let slices = [IoSlice::new(&wire)];
@@ -700,7 +702,7 @@ pub(crate) fn handle_msg_for_test(
     cache: std::sync::Arc<ClientCache>,
     msg: &node_lib::messages::message::Message<'_>,
 ) -> anyhow::Result<Option<Vec<ReplyType>>> {
-    use node_lib::messages::{control::Control, data::Data, packet_type::PacketType};
+    use node_lib::messages::{auth::Auth, control::Control, data::Data, packet_type::PacketType};
 
     match msg.get_packet_type() {
         PacketType::Data(Data::Upstream(buf)) => {
@@ -731,9 +733,9 @@ pub(crate) fn handle_msg_for_test(
         }
         PacketType::Data(Data::Downstream(_))
         | PacketType::Control(Control::Heartbeat(_))
-        | PacketType::Control(Control::KeyExchangeInit(_))
-        | PacketType::Control(Control::KeyExchangeReply(_))
-        | PacketType::Control(Control::SessionTerminated(_)) => Ok(None),
+        | PacketType::Auth(Auth::KeyExchangeInit(_))
+        | PacketType::Auth(Auth::KeyExchangeReply(_))
+        | PacketType::Auth(Auth::SessionTerminated(_)) => Ok(None),
     }
 }
 

--- a/server_lib/src/cloud_protocol.rs
+++ b/server_lib/src/cloud_protocol.rs
@@ -1,6 +1,7 @@
 use crate::registry::{self, RegistrationMessage};
 use anyhow::{bail, Result};
 use mac_address::MacAddress;
+use node_lib::crypto::SigningAlgorithm;
 
 /// Message type byte for upstream data forwarding (RSU -> Server).
 pub const UPSTREAM_TYPE: u8 = 0x02;
@@ -305,8 +306,8 @@ pub struct SessionTerminatedForward {
     pub timestamp_secs: Option<u64>,
     /// 8-byte server-generated random nonce.
     pub nonce: Option<[u8; 8]>,
-    /// Signature algorithm ID (optional; same constants as KeyExchange).
-    pub sig_algo_id: Option<u8>,
+    /// Signature algorithm (optional; same algorithms as KeyExchange).
+    pub sig_algo: Option<SigningAlgorithm>,
     /// Raw signature over `[0x04][OBU_MAC 6B][TIMESTAMP_SECS 8B][NONCE 8B]`.
     pub signature: Option<Vec<u8>>,
 }
@@ -317,7 +318,7 @@ impl SessionTerminatedForward {
             obu_mac,
             timestamp_secs: None,
             nonce: None,
-            sig_algo_id: None,
+            sig_algo: None,
             signature: None,
         }
     }
@@ -326,14 +327,14 @@ impl SessionTerminatedForward {
         obu_mac: MacAddress,
         timestamp_secs: u64,
         nonce: [u8; 8],
-        sig_algo_id: u8,
+        sig_algo: SigningAlgorithm,
         signature: Vec<u8>,
     ) -> Self {
         Self {
             obu_mac,
             timestamp_secs: Some(timestamp_secs),
             nonce: Some(nonce),
-            sig_algo_id: Some(sig_algo_id),
+            sig_algo: Some(sig_algo),
             signature: Some(signature),
         }
     }
@@ -343,15 +344,15 @@ impl SessionTerminatedForward {
         buf.extend_from_slice(&registry::MAGIC);
         buf.push(SESSION_TERMINATED_TYPE);
         buf.extend_from_slice(&self.obu_mac.bytes());
-        if let (Some(ts), Some(nonce), Some(algo_id), Some(sig)) = (
+        if let (Some(ts), Some(nonce), Some(algo), Some(sig)) = (
             self.timestamp_secs,
             self.nonce,
-            self.sig_algo_id,
+            self.sig_algo,
             self.signature.as_deref(),
         ) {
             buf.extend_from_slice(&ts.to_be_bytes());
             buf.extend_from_slice(&nonce);
-            buf.push(algo_id);
+            buf.push(algo.wire_id());
             let sig_len = sig.len() as u16;
             buf.extend_from_slice(&sig_len.to_be_bytes());
             buf.extend_from_slice(sig);
@@ -378,7 +379,7 @@ impl SessionTerminatedForward {
             }
             let timestamp_secs = u64::from_be_bytes(data[9..17].try_into().ok()?);
             let nonce: [u8; 8] = data[17..25].try_into().ok()?;
-            let sig_algo_id = data[25];
+            let sig_algo = SigningAlgorithm::from_wire_id(data[25])?;
             let sig_len = u16::from_be_bytes([data[26], data[27]]) as usize;
             if data.len() < 28 + sig_len {
                 return None;
@@ -388,7 +389,7 @@ impl SessionTerminatedForward {
                 obu_mac,
                 timestamp_secs: Some(timestamp_secs),
                 nonce: Some(nonce),
-                sig_algo_id: Some(sig_algo_id),
+                sig_algo: Some(sig_algo),
                 signature: Some(signature),
             });
         }
@@ -397,7 +398,7 @@ impl SessionTerminatedForward {
             obu_mac,
             timestamp_secs: None,
             nonce: None,
-            sig_algo_id: None,
+            sig_algo: None,
             signature: None,
         })
     }

--- a/server_lib/src/server.rs
+++ b/server_lib/src/server.rs
@@ -5,9 +5,7 @@ use crate::registry::RegistrationMessage;
 use anyhow::Result;
 use common::tun::Tun;
 use mac_address::MacAddress;
-use node_lib::crypto::{
-    sig_algo_from_id, CryptoConfig, DhKeypair, SigningAlgorithm, SigningKeypair,
-};
+use node_lib::crypto::{CryptoConfig, DhKeypair, SigningAlgorithm, SigningKeypair};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -737,7 +735,7 @@ impl Server {
         );
         let allowlist = dh_signing_allowlist.read().await;
         // Parse the KeyExchangeInit payload
-        let ke_init = match node_lib::messages::control::key_exchange::KeyExchangeInit::try_from(
+        let ke_init = match node_lib::messages::auth::key_exchange::KeyExchangeInit::try_from(
             ke_fwd.payload.as_slice(),
         ) {
             Ok(init) => init,
@@ -754,22 +752,11 @@ impl Server {
         // Verify the OBU's signature if signatures are required.
         if enable_dh_signatures {
             match (
-                ke_init.sig_algo_id(),
+                ke_init.signing_algorithm(),
                 ke_init.signing_pubkey(),
                 ke_init.signature(),
             ) {
-                (Some(sig_algo), Some(spk), Some(sig)) => {
-                    let algo = match sig_algo_from_id(sig_algo) {
-                        Some(a) => a,
-                        None => {
-                            tracing::warn!(
-                                obu = %ke_fwd.obu_mac,
-                                sig_algo_id = sig_algo,
-                                "KeyExchangeInit uses unknown signature algorithm, dropping"
-                            );
-                            return;
-                        }
-                    };
+                (Some(algo), Some(spk), Some(sig)) => {
                     let base = ke_init.base_payload();
                     if let Err(e) = node_lib::crypto::verify_dh_signature(algo, &base, spk, sig) {
                         tracing::warn!(
@@ -842,23 +829,17 @@ impl Server {
         drop(allowlist);
 
         let key_id = ke_init.key_id();
-        let algo_id = ke_init.algo_id();
+        let dh_group = ke_init.dh_group();
 
         // Reject key exchanges that use an algorithm the server isn't configured for.
-        // An attacker could otherwise downgrade the algorithm by rewriting algo_id
-        // in a forwarded KeyExchangeInit.
         {
-            use node_lib::messages::control::key_exchange::{KE_ALGO_ML_KEM_768, KE_ALGO_X25519};
-            let expected_algo_id = match crypto_config.dh_group {
-                node_lib::crypto::DhGroup::X25519 => KE_ALGO_X25519,
-                node_lib::crypto::DhGroup::MlKem768 => KE_ALGO_ML_KEM_768,
-            };
-            if algo_id != expected_algo_id {
+            let expected_group = crypto_config.dh_group;
+            if dh_group != Some(expected_group) {
                 tracing::warn!(
                     obu = %ke_fwd.obu_mac,
-                    algo_id = algo_id,
-                    expected = expected_algo_id,
-                    "KeyExchangeInit algo_id does not match server crypto config, dropping"
+                    dh_group = ?dh_group,
+                    expected = %expected_group,
+                    "KeyExchangeInit dh_group does not match server crypto config, dropping"
                 );
                 return;
             }
@@ -881,13 +862,11 @@ impl Server {
             }
         }
 
-        use node_lib::messages::control::key_exchange::{
-            KE_ALGO_ML_KEM_768, KE_ALGO_X25519, SIG_ALGO_ED25519, SIG_ALGO_ML_DSA_65,
-        };
+        use node_lib::crypto::DhGroup;
 
         // Perform the key exchange based on the algorithm in the init message.
-        let (our_reply_material, shared_secret_bytes) = match algo_id {
-            KE_ALGO_X25519 => {
+        let (our_reply_material, shared_secret_bytes) = match dh_group {
+            Some(DhGroup::X25519) => {
                 let peer_pub_bytes: [u8; 32] = match ke_init.key_material().try_into() {
                     Ok(b) => b,
                     Err(_) => {
@@ -901,7 +880,7 @@ impl Server {
                 let ss = our_keypair.diffie_hellman(&peer_public).as_bytes().to_vec();
                 (our_public, ss)
             }
-            KE_ALGO_ML_KEM_768 => {
+            Some(DhGroup::MlKem768) => {
                 let ek_bytes: &[u8; node_lib::crypto::ML_KEM_768_EK_LEN] =
                     match ke_init.key_material().try_into() {
                         Ok(b) => b,
@@ -926,11 +905,10 @@ impl Server {
                     }
                 }
             }
-            _ => {
+            None => {
                 tracing::warn!(
                     obu = %ke_fwd.obu_mac,
-                    algo_id = algo_id,
-                    "Unknown key exchange algorithm, dropping"
+                    "Unknown key exchange algorithm in KeyExchangeInit, dropping"
                 );
                 return;
             }
@@ -968,7 +946,7 @@ impl Server {
             obu = %ke_fwd.obu_mac,
             rsu = %ke_fwd.rsu_mac,
             key_id = key_id,
-            algo_id = algo_id,
+            dh_group = ?dh_group,
             cipher = %crypto_config.cipher,
             kdf = %crypto_config.kdf,
             key_len = key_len,
@@ -979,40 +957,31 @@ impl Server {
         // Set sender = obu_mac so relay OBUs know who the final recipient is.
         // Sign the reply if signatures are enabled.
         let ke_reply = if let Some(kp) = signing_keypair {
-            let sig_algo_id = match kp.signing_algorithm() {
-                SigningAlgorithm::Ed25519 => SIG_ALGO_ED25519,
-                SigningAlgorithm::MlDsa65 => SIG_ALGO_ML_DSA_65,
-            };
-            let unsigned = node_lib::messages::control::key_exchange::KeyExchangeReply::new_raw(
-                algo_id,
+            let sig_algo = kp.signing_algorithm();
+            let unsigned = node_lib::messages::auth::key_exchange::KeyExchangeReply::new_unsigned(
+                crypto_config.dh_group,
                 key_id,
                 our_reply_material.clone(),
                 ke_fwd.obu_mac,
-                None,
-                None,
-                None,
             );
             let base = unsigned.base_payload();
             let sig = kp.sign(&base);
             let spk = kp.verifying_key_bytes();
-            node_lib::messages::control::key_exchange::KeyExchangeReply::new_raw(
-                algo_id,
+            node_lib::messages::auth::key_exchange::KeyExchangeReply::new_signed(
+                crypto_config.dh_group,
                 key_id,
                 our_reply_material,
                 ke_fwd.obu_mac,
-                Some(sig_algo_id),
-                Some(spk),
-                Some(sig),
+                sig_algo,
+                spk,
+                sig,
             )
         } else {
-            node_lib::messages::control::key_exchange::KeyExchangeReply::new_raw(
-                algo_id,
+            node_lib::messages::auth::key_exchange::KeyExchangeReply::new_unsigned(
+                crypto_config.dh_group,
                 key_id,
                 our_reply_material,
                 ke_fwd.obu_mac,
-                None,
-                None,
-                None,
             )
         };
         let reply_bytes: Vec<u8> = (&ke_reply).into();
@@ -1113,12 +1082,7 @@ impl Server {
 
         // Notify the RSU so the OBU can react promptly.
         if let Some(rsu_addr) = rsu_addr {
-            // Sign the revocation if a signing keypair is available.
-            // A fresh random nonce is generated for each revocation and included in
-            // the signed payload: [CONTROL_TYPE=0x04][TARGET_OBU_MAC 6B][NONCE 16B].
-            // The nonce is opaque random bytes — it reveals nothing about the session
-            // and prevents replay: the OBU tracks seen nonces and drops duplicates.
-            use node_lib::messages::control::key_exchange::{SIG_ALGO_ED25519, SIG_ALGO_ML_DSA_65};
+            use node_lib::messages::auth::session_terminated::SessionTerminated;
             use rand_core::{OsRng, RngCore};
             use std::time::{SystemTime, UNIX_EPOCH};
             let fwd = if let Some(ref kp) = self.signing_keypair {
@@ -1128,16 +1092,11 @@ impl Server {
                     .as_secs();
                 let mut nonce = [0u8; 8];
                 OsRng.fill_bytes(&mut nonce);
-                let mut payload = vec![0x04u8]; // SessionTerminated control type byte
-                payload.extend_from_slice(&obu_mac.bytes());
-                payload.extend_from_slice(&timestamp_secs.to_be_bytes());
-                payload.extend_from_slice(&nonce);
+                let sig_algo = kp.signing_algorithm();
+                let payload =
+                    SessionTerminated::build_signed_payload(obu_mac, timestamp_secs, nonce);
                 let sig = kp.sign(&payload);
-                let algo_id = match kp.signing_algorithm() {
-                    SigningAlgorithm::Ed25519 => SIG_ALGO_ED25519,
-                    SigningAlgorithm::MlDsa65 => SIG_ALGO_ML_DSA_65,
-                };
-                SessionTerminatedForward::new_signed(obu_mac, timestamp_secs, nonce, algo_id, sig)
+                SessionTerminatedForward::new_signed(obu_mac, timestamp_secs, nonce, sig_algo, sig)
             } else {
                 SessionTerminatedForward::new(obu_mac)
             };


### PR DESCRIPTION
- What: Move KeyExchangeInit, KeyExchangeReply, SessionTerminated into a new Auth enum under node_lib::messages::auth/; strip Control to only Heartbeat and HeartbeatReply
- Why: Auth messages have different lifecycle and security semantics from routing control messages; separating them improves clarity and enforces the rule that algorithm IDs are an internal wire detail
- How: New auth/ module with typed constructors (new_unsigned/new_signed) and typed accessors (dh_group(), signing_algorithm()) backed by private wire-ID constants; DhGroup/SigningAlgorithm gain wire_id()/from_wire_id() methods; removed sig_algo_from_id() from crypto.rs; PacketType::Auth gets wire ID 2; all callers in obu_lib, rsu_lib, server_lib updated; cloud_protocol::SessionTerminatedForward.sig_algo_id changed to sig_algo: Option<SigningAlgorithm>; old control/key_exchange.rs and control/session_terminated.rs deleted
- Testing: cargo test --workspace --features test_helpers (all passed), cargo clippy --workspace --all-targets -- -D warnings (clean), cargo build --workspace (clean), cargo fmt (applied)

<!-- Use this template to create clear, well-scoped pull requests. -->

## Summary

- What: A short, one-line description of the change.
- Why: Why this change is necessary.

## Implementation

- How: Brief notes about the approach taken and the main files changed.

## Testing

- Tests added: Yes/No
- How to run locally:

```bash
# Build and run tests with test helpers
cargo test --workspace --features test_helpers
```

## Checklist

- [ ] Commit message follows Conventional Commits format
- [ ] Code formatted (cargo fmt)
- [ ] Lints fixed (cargo clippy)
- [ ] Tests added or updated
- [ ] CI passes

## Notes

Include any additional context or links to related issues.
