### PR TITLE
fix(native_viz): remove redundant guard in match arm

### DIFF
--- a/native_viz/src/app.rs
+++ b/native_viz/src/app.rs
@@ -232,7 +232,7 @@ fn draw_sidebar(
                         .color(egui::Color32::YELLOW),
                 );
             }
-            n if n == 1 => {
+            1 => {
                 ui.label(
                     egui::RichText::new("1 match")
                         .small()


### PR DESCRIPTION
- What: Replace `n if n == 1` with literal `1` pattern in match arm
- Why: Clippy `-D warnings` treats `redundant_guards` as an error, breaking CI
- How: Replace redundant guard expression with direct literal pattern match
- Testing: cargo clippy --workspace --all-targets -- -D warnings (passed)